### PR TITLE
Derive __version__ from package metadata and bump to 0.2.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bank-statement-parser"
-version = "0.1.0"
+version = "0.2.0a1"
 description = "Parse bank statement PDFs, extract transactions, and persist to Parquet and SQLite."
 readme = "README.md"
 license = "MIT"

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -61,8 +61,10 @@ Errors
     bsp.ProjectConfigMissing    -- config/ absent or empty in an otherwise-valid project
 """
 
+from importlib.metadata import version as _pkg_version
+
 __app_name__ = "bank-statement-parser"
-__version__ = "0.1.0"
+__version__ = _pkg_version(__app_name__)
 
 # ---------------------------------------------------------------------------
 # Namespaced report backends — import the sub-modules so callers can do

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "bank-statement-parser"
-version = "0.1.0"
+version = "0.2.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "dacite" },


### PR DESCRIPTION
## Summary

- Replace the hard-coded `__version__ = "0.1.0"` in `__init__.py` with a dynamic read from `importlib.metadata.version()`, so `pyproject.toml` is the single source of truth for the package version.
- Bump version from `0.1.0` to `0.2.0a1` in preparation for the first published release.

## Changes

- **`src/bank_statement_parser/__init__.py`** — import `importlib.metadata.version` and derive `__version__` from installed package metadata at import time.
- **`pyproject.toml`** — version bumped to `0.2.0a1`.
- **`uv.lock`** — updated automatically by `uv sync`.

## Why

Maintaining the version string in two places (`pyproject.toml` and `__init__.py`) is a maintenance risk — they can drift out of sync. With this change, only `pyproject.toml` needs to be updated when releasing a new version.