### PR TITLE
get_paths() retirement

### DIFF
--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -45,35 +45,6 @@ initialised via `validate_or_initialise_project()`. The decision table is:
 
 ## Python API
 
-### `get_paths()`
-
-```python
-get_paths(project_path: Path | None = None) -> ProjectPaths
-```
-
-Return a :class:`ProjectPaths` for the given project root.
-
-When *project_path* is ``None``, the default project folder bundled with
-the package is used (``src/bank_statement_parser/project/``).
-
-This is a pure path-computation factory. It does **not** validate that the
-project directory exists or is correctly structured — use
-:func:`validate_or_initialise_project` for that (called automatically by
-:class:`~bank_statement_parser.modules.statements.Statement` and
-:class:`~bank_statement_parser.modules.statements.StatementBatch`).
-
-
-**Args:**
-
-- `project_path` — Root of the project directory tree.  Must follow the
-  standard sub-directory layout (``config/``, ``parquet/``,
-  ``database/``, etc.).
-
-
-**Returns:**
-
-- `A` — class:`ProjectPaths` instance with all derived path attributes.
-
 ### `copy_project_folders()`
 
 ```python

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -107,6 +107,12 @@ Copy the project folder structure (directories only) to a destination.
 
 Validate an existing project or initialise a new one at *project_path*.
 
+### `bsp.ProjectPaths`
+
+*class* — `bank_statement_parser.modules.paths`
+
+All file-system paths for a bank_statement_parser project, derived from a single root directory.
+
 ## Low-level PDF helpers
 
 ### `bsp.pdf_open()`

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -96,7 +96,7 @@ from bank_statement_parser.modules.errors import (
 # Config helpers
 # ---------------------------------------------------------------------------
 from bank_statement_parser.modules.config import copy_default_config
-from bank_statement_parser.modules.paths import copy_project_folders, validate_or_initialise_project
+from bank_statement_parser.modules.paths import ProjectPaths, copy_project_folders, validate_or_initialise_project
 
 # ---------------------------------------------------------------------------
 # PDF anonymisation utility
@@ -142,6 +142,7 @@ __all__ = [
     "copy_default_config",
     "copy_project_folders",
     "validate_or_initialise_project",
+    "ProjectPaths",
     # Low-level PDF helpers
     "pdf_open",
     "page_crop",

--- a/src/bank_statement_parser/cli.py
+++ b/src/bank_statement_parser/cli.py
@@ -67,7 +67,7 @@ def _cmd_process(args: argparse.Namespace) -> int:
     Returns:
         Exit code (0 = success, 1 = error).
     """
-    from bank_statement_parser.modules.paths import get_paths
+    from bank_statement_parser.modules.paths import ProjectPaths
     from bank_statement_parser.modules.statements import StatementBatch
 
     # -- resolve PDF directory and discover files ----------------------------
@@ -116,7 +116,7 @@ def _cmd_process(args: argparse.Namespace) -> int:
     batch.delete_temp_files()
 
     # -- summary -------------------------------------------------------------
-    paths = get_paths(project_path)
+    paths = ProjectPaths.resolve(project_path)
     print("")
     print(f"Done — processed {batch.pdf_count} PDF(s) ({batch.errors} error(s)) in {batch.duration_secs:.1f}s.")
     print("")

--- a/src/bank_statement_parser/modules/config.py
+++ b/src/bank_statement_parser/modules/config.py
@@ -26,7 +26,7 @@ from bank_statement_parser.modules.data import (
     StatementType,
 )
 from bank_statement_parser.modules.errors import ProjectConfigMissing, StatementError
-from bank_statement_parser.modules.paths import BASE_CONFIG, get_paths
+from bank_statement_parser.modules.paths import BASE_CONFIG, ProjectPaths
 from bank_statement_parser.modules.statement_functions import get_results
 
 
@@ -136,7 +136,7 @@ class ConfigManager:
     def config_dir(self) -> Path:
         """Return the effective configuration directory path."""
         if self._project_path is not None:
-            return get_paths(self._project_path).config
+            return ProjectPaths.resolve(self._project_path).config
         return BASE_CONFIG
 
     @property

--- a/src/bank_statement_parser/modules/database.py
+++ b/src/bank_statement_parser/modules/database.py
@@ -15,7 +15,7 @@ import polars as pl
 from bank_statement_parser.data.build_datamart import build_datamart, _ensure_mart_structure
 from bank_statement_parser.modules.data import PdfResult
 from bank_statement_parser.modules.errors import ProjectDatabaseMissing
-from bank_statement_parser.modules.paths import get_paths
+from bank_statement_parser.modules.paths import ProjectPaths
 
 # Python 3.12+ deprecates the built-in date/datetime adapters for sqlite3.
 # Register explicit ISO-format adapters so that datetime.date and
@@ -366,7 +366,7 @@ def update_db(
         ProjectDatabaseMissing: If ``database/project.db`` does not exist under
             the resolved project root.
     """
-    paths = get_paths(project_path)
+    paths = ProjectPaths.resolve(project_path)
     db_path = paths.project_db
 
     _require_db(db_path)

--- a/src/bank_statement_parser/modules/debug.py
+++ b/src/bank_statement_parser/modules/debug.py
@@ -26,7 +26,7 @@ from bank_statement_parser.modules.parquet import (
     _build_statement_heads_data,
     _build_statement_lines_data,
 )
-from bank_statement_parser.modules.paths import get_paths
+from bank_statement_parser.modules.paths import ProjectPaths
 from bank_statement_parser.modules.statement_functions import get_results
 
 
@@ -461,7 +461,7 @@ def debug_pdf_statement(
         # ----------------------------------------------------------------
         # 6. Write debug.json
         # ----------------------------------------------------------------
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         folder_name = f"{pdf.parent.name}_{pdf.name}"
         debug_dir = paths.log_debug_dir(folder_name)
         debug_dir.mkdir(parents=True, exist_ok=True)

--- a/src/bank_statement_parser/modules/parquet.py
+++ b/src/bank_statement_parser/modules/parquet.py
@@ -23,7 +23,7 @@ from time import time
 import polars as pl
 
 from bank_statement_parser.modules.data import PdfResult
-from bank_statement_parser.modules.paths import ProjectPaths, get_paths
+from bank_statement_parser.modules.paths import ProjectPaths
 
 
 class Parquet:
@@ -80,43 +80,300 @@ class Parquet:
             self.file.unlink()
 
 
-def _resolve_parquet_file(
-    paths: ProjectPaths,
-    default: Path,
-    filename: str | None,
-) -> Path:
+def _load_source(source: Path) -> pl.DataFrame:
+    """Read a parquet file and drop the ``index`` column.
+
+    Args:
+        source: Path to the parquet file to read.
+
+    Returns:
+        DataFrame with the ``index`` column removed.
     """
-    Return the full Path for a parquet file, validating the parquet directory.
+    return pl.read_parquet(source).drop("index")
 
-    If *filename* is provided (bare stem, no extension, no directory), the
-    full path is ``paths.parquet / f"{filename}.parquet"``.  Otherwise the
-    *default* path is used.
 
-    A :exc:`ProjectSubFolderNotFound` is raised if the parquet directory does
-    not exist.
+class ChecksAndBalances(Parquet):
+    """Parquet wrapper for checks-and-balances records.
+
+    Args:
+        file: Destination parquet file path.
+        source: Optional separate source path to read initial records from.
+            When provided, records are loaded from *source* rather than built
+            from the data arguments.  When omitted, *file* is used as the
+            source when reading existing data (via the base class).
+        id_statement: Unique statement identifier (required when building
+            records from raw data).
+        id_batch: Batch identifier (required when building records from raw
+            data).
+        checks_and_balances: Raw checks-and-balances DataFrame from
+            :class:`~bank_statement_parser.modules.statements.Statement`
+            (required when building records from raw data).
     """
-    paths.require_subdir_for_read(paths.parquet)
-    if filename is not None:
-        return paths.parquet / f"{filename}.parquet"
-    return default
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        file: Path,
+        source: Path | None = None,
+        id_statement: str | None = None,
+        id_batch: str | None = None,
+        checks_and_balances: pl.DataFrame | None = None,
+    ) -> None:
+        self.schema = pl.DataFrame(
+            orient="row",
+            schema={
+                "ID_CAB": pl.Utf8,
+                "ID_STATEMENT": pl.Utf8,
+                "ID_BATCH": pl.Utf8,
+                "HAS_TRANSACTIONS": pl.Boolean,
+                "STD_OPENING_BALANCE_HEADS": pl.Decimal(16, 4),
+                "STD_PAYMENTS_IN_HEADS": pl.Decimal(16, 4),
+                "STD_PAYMENTS_OUT_HEADS": pl.Decimal(16, 4),
+                "STD_MOVEMENT_HEADS": pl.Decimal(16, 4),
+                "STD_CLOSING_BALANCE_HEADS": pl.Decimal(16, 4),
+                "STD_OPENING_BALANCE_LINES": pl.Decimal(16, 4),
+                "STD_PAYMENTS_IN_LINES": pl.Decimal(16, 4),
+                "STD_PAYMENTS_OUT_LINES": pl.Decimal(16, 4),
+                "STD_MOVEMENT_LINES": pl.Decimal(16, 4),
+                "STD_CLOSING_BALANCE_LINES": pl.Decimal(16, 4),
+                "CHECK_PAYMENTS_IN": pl.Boolean,
+                "CHECK_PAYMENTS_OUT": pl.Boolean,
+                "CHECK_MOVEMENT": pl.Boolean,
+                "CHECK_CLOSING": pl.Boolean,
+            },
+        )
+        self.key = "ID_CAB"
+        self.records: pl.DataFrame | None = None
+
+        if source is not None:
+            self.records = _load_source(source)
+        elif checks_and_balances is not None and id_statement is not None and id_batch is not None:
+            self.records = build_checks_and_balances_records(self.schema, id_statement, id_batch, checks_and_balances)
+
+        super().__init__(file, self.schema, self.records, self.key)
 
 
-# ---------------------------------------------------------------------------
-# build_*_records() helpers
-# ---------------------------------------------------------------------------
-# Each function reproduces the DataFrame construction that was previously
-# inlined in the corresponding Parquet subclass constructor.  Extracting them
-# makes it possible for the debug path (debug.py) to call the same logic
-# independently — without constructing a full Parquet object — and to wrap
-# the call in diagnostics that capture schema mismatches.
-#
-# For the three per-statement classes (ChecksAndBalances, StatementHeads,
-# StatementLines) a private ``_build_*_data()`` function builds just the
-# data DataFrame *without* calling ``.extend()``.  The public
-# ``build_*_records()`` function calls it and then extends the schema.
-# This split gives the debug path access to the intermediate data so it
-# can compare dtypes column-by-column when ``.extend()`` fails.
-# ---------------------------------------------------------------------------
+class StatementHeads(Parquet):
+    """Parquet wrapper for statement header records.
+
+    Args:
+        file: Destination parquet file path.
+        source: Optional separate source path to read initial records from.
+        id_statement: Unique statement identifier.
+        id_batchline: Batch-line identifier.
+        id_account: Account identifier.
+        company: Company name.
+        statement_type: Statement type label.
+        account: Account label.
+        header_results: LazyFrame of extracted header fields.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        file: Path,
+        source: Path | None = None,
+        id_statement: str | None = None,
+        id_batchline: str | None = None,
+        id_account: str | None = None,
+        company: str | None = None,
+        statement_type: str | None = None,
+        account: str | None = None,
+        header_results: pl.LazyFrame | None = None,
+    ) -> None:
+        self.schema = pl.DataFrame(
+            orient="row",
+            schema={
+                "ID_STATEMENT": pl.Utf8,
+                "ID_BATCHLINE": pl.Utf8,
+                "ID_ACCOUNT": pl.Utf8,
+                "STD_COMPANY": pl.Utf8,
+                "STD_STATEMENT_TYPE": pl.Utf8,
+                "STD_ACCOUNT": pl.Utf8,
+                "STD_SORTCODE": pl.Utf8,
+                "STD_ACCOUNT_NUMBER": pl.Utf8,
+                "STD_ACCOUNT_HOLDER": pl.Utf8,
+                "STD_STATEMENT_DATE": pl.Date,
+                "STD_OPENING_BALANCE": pl.Decimal(16, 4),
+                "STD_PAYMENTS_IN": pl.Decimal(16, 4),
+                "STD_PAYMENTS_OUT": pl.Decimal(16, 4),
+                "STD_CLOSING_BALANCE": pl.Decimal(16, 4),
+            },
+        )
+        self.key = "ID_STATEMENT"
+        self.records: pl.DataFrame | None = None
+
+        if source is not None:
+            self.records = _load_source(source)
+        elif header_results is not None and id_statement is not None:
+            self.records = build_statement_heads_records(
+                self.schema, id_statement, id_batchline, id_account, company, statement_type, account, header_results
+            )
+
+        super().__init__(file, self.schema, self.records, self.key)
+
+
+class StatementLines(Parquet):
+    """Parquet wrapper for statement transaction-line records.
+
+    Args:
+        file: Destination parquet file path.
+        source: Optional separate source path to read initial records from.
+        id_statement: Unique statement identifier.
+        lines_results: LazyFrame of extracted transaction lines.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        file: Path,
+        source: Path | None = None,
+        id_statement: str | None = None,
+        lines_results: pl.LazyFrame | None = None,
+    ) -> None:
+        self.schema = pl.DataFrame(
+            orient="row",
+            schema={
+                "ID_TRANSACTION": pl.Utf8,
+                "ID_STATEMENT": pl.Utf8,
+                "STD_PAGE_NUMBER": pl.Int32,
+                "STD_TRANSACTION_DATE": pl.Date,
+                "STD_TRANSACTION_NUMBER": pl.UInt32,
+                "STD_CD": pl.Utf8,
+                "STD_TRANSACTION_TYPE": pl.Utf8,
+                "STD_TRANSACTION_TYPE_CD": pl.Utf8,
+                "STD_TRANSACTION_DESC": pl.Utf8,
+                "STD_OPENING_BALANCE": pl.Decimal(16, 4),
+                "STD_PAYMENTS_IN": pl.Decimal(16, 4),
+                "STD_PAYMENTS_OUT": pl.Decimal(16, 4),
+                "STD_CLOSING_BALANCE": pl.Decimal(16, 4),
+            },
+        )
+        self.key = "ID_TRANSACTION"
+        self.records: pl.DataFrame | None = None
+
+        if source is not None:
+            self.records = _load_source(source)
+        elif lines_results is not None and id_statement is not None:
+            self.records = build_statement_lines_records(self.schema, id_statement, lines_results)
+
+        super().__init__(file, self.schema, self.records, self.key)
+
+
+class BatchHeads(Parquet):
+    """Parquet wrapper for batch header metadata.
+
+    Args:
+        file: Destination parquet file path.
+        batch_id: Unique batch identifier.
+        session_id: UUID4 session identifier.
+        user_id: OS username of the user who initiated the batch.
+        path: String representation of PDF source directories.
+        company_key: Company identifier.
+        account_key: Account identifier.
+        pdf_count: Total number of PDFs in the batch.
+        errors: Count of failed statement processings.
+        duration_secs: Total processing time (seconds).
+        process_time: Timestamp when batch processing started.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        file: Path,
+        batch_id: str | None = None,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        path: str | None = None,
+        company_key: str | None = None,
+        account_key: str | None = None,
+        pdf_count: int | None = None,
+        errors: int | None = None,
+        duration_secs: float | None = None,
+        process_time: datetime | None = None,
+    ) -> None:
+        self.schema = pl.DataFrame(
+            orient="row",
+            schema={
+                "ID_BATCH": pl.Utf8,
+                "ID_SESSION": pl.Utf8,
+                "ID_USER": pl.Utf8,
+                "STD_PATH": pl.Utf8,
+                "STD_COMPANY": pl.Utf8,
+                "STD_ACCOUNT": pl.Utf8,
+                "STD_PDF_COUNT": pl.Int64,
+                "STD_ERROR_COUNT": pl.Int64,
+                "STD_DURATION_SECS": pl.Float64,
+                "STD_UPDATETIME": pl.Datetime,
+            },
+        )
+        self.records: pl.DataFrame | None = None
+        if batch_id is not None:
+            self.records = build_batch_heads_records(
+                self.schema,
+                batch_id,
+                session_id or "",
+                user_id or "",
+                path,
+                company_key,
+                account_key,
+                pdf_count,
+                errors,
+                duration_secs,
+                process_time,
+            )
+        self.key = "ID_BATCH"
+        super().__init__(file, self.schema, self.records, self.key)
+
+
+class BatchLines(Parquet):
+    """Parquet wrapper for per-PDF batch-line records.
+
+    Args:
+        file: Destination parquet file path.
+        source: Optional separate source path to read initial records from.
+        batch_lines: List of dicts, one per PDF, with batch-line metadata.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        file: Path,
+        source: Path | None = None,
+        batch_lines: list[dict] | None = None,
+    ) -> None:
+        self.schema = pl.DataFrame(
+            orient="row",
+            schema={
+                "ID_BATCH": pl.Utf8,
+                "ID_BATCHLINE": pl.Utf8,
+                "ID_STATEMENT": pl.Utf8,
+                "STD_BATCH_LINE": pl.Int64,
+                "STD_FILENAME": pl.Utf8,
+                "STD_ACCOUNT": pl.Utf8,
+                "STD_DURATION_SECS": pl.Float64,
+                "STD_UPDATETIME": pl.Datetime,
+                "STD_SUCCESS": pl.Boolean,
+                "STD_ERROR_MESSAGE": pl.Utf8,
+                "ERROR_CAB": pl.Boolean,
+                "ERROR_CONFIG": pl.Boolean,
+                "ERROR_DATA": pl.Boolean,
+            },
+        )
+        self.key = "ID_BATCHLINE"
+        self.records: pl.DataFrame | None = None
+
+        if source is not None:
+            self.records = _load_source(source)
+        elif batch_lines:
+            self.records = build_batch_lines_records(self.schema, batch_lines)
+
+        super().__init__(file, self.schema, self.records, self.key)
 
 
 def _build_checks_and_balances_data(
@@ -371,286 +628,6 @@ def build_batch_lines_records(
     return schema.clone().extend(pl.DataFrame(batch_lines))
 
 
-class ChecksAndBalances(Parquet):
-    __slots__ = ("id", "source_filename", "destination_filename", "project_path")
-
-    def __init__(
-        self,
-        id_statement: str | None = None,
-        id_batch: str | None = None,
-        checks_and_balances: pl.DataFrame | None = None,
-        id: int = -1,
-        source_filename: str | None = None,
-        destination_filename: str | None = None,
-        project_path: Path | None = None,
-    ) -> None:
-        self.id = id
-        self.source_filename = source_filename
-        self.destination_filename = destination_filename
-        self.project_path = project_path
-        paths = get_paths(project_path)
-        self.schema = pl.DataFrame(
-            orient="row",
-            schema={
-                "ID_CAB": pl.Utf8,
-                "ID_STATEMENT": pl.Utf8,
-                "ID_BATCH": pl.Utf8,
-                "HAS_TRANSACTIONS": pl.Boolean,
-                "STD_OPENING_BALANCE_HEADS": pl.Decimal(16, 4),
-                "STD_PAYMENTS_IN_HEADS": pl.Decimal(16, 4),
-                "STD_PAYMENTS_OUT_HEADS": pl.Decimal(16, 4),
-                "STD_MOVEMENT_HEADS": pl.Decimal(16, 4),
-                "STD_CLOSING_BALANCE_HEADS": pl.Decimal(16, 4),
-                "STD_OPENING_BALANCE_LINES": pl.Decimal(16, 4),
-                "STD_PAYMENTS_IN_LINES": pl.Decimal(16, 4),
-                "STD_PAYMENTS_OUT_LINES": pl.Decimal(16, 4),
-                "STD_MOVEMENT_LINES": pl.Decimal(16, 4),
-                "STD_CLOSING_BALANCE_LINES": pl.Decimal(16, 4),
-                "CHECK_PAYMENTS_IN": pl.Boolean,
-                "CHECK_PAYMENTS_OUT": pl.Boolean,
-                "CHECK_MOVEMENT": pl.Boolean,
-                "CHECK_CLOSING": pl.Boolean,
-            },
-        )
-        self.key = "ID_CAB"
-        self.records: pl.DataFrame | None = None
-
-        # Determine the source file (temp file written by process_pdf_statement)
-        source_default = paths.cab_temp(self.id) if self.id > -1 else paths.cab
-        source_file = _resolve_parquet_file(paths, source_default, source_filename)
-
-        if source_filename is not None:
-            self.records = pl.read_parquet(source_file).drop("index")
-        elif checks_and_balances is not None and id_statement is not None and id_batch is not None:
-            self.records = build_checks_and_balances_records(self.schema, id_statement, id_batch, checks_and_balances)
-
-        # Determine the destination file
-        dest_default = paths.cab_temp(self.id) if self.id > -1 else paths.cab
-        destination_file = _resolve_parquet_file(paths, dest_default, destination_filename)
-
-        super().__init__(destination_file, self.schema, self.records, self.key)
-
-
-class StatementHeads(Parquet):
-    __slots__ = ("id", "source_filename", "destination_filename", "project_path")
-
-    def __init__(
-        self,
-        id_statement: str | None = None,
-        id_batchline: str | None = None,
-        id_account: str | None = None,
-        company: str | None = None,
-        statement_type: str | None = None,
-        account: str | None = None,
-        header_results: pl.LazyFrame | None = None,
-        id: int = -1,
-        source_filename: str | None = None,
-        destination_filename: str | None = None,
-        project_path: Path | None = None,
-    ) -> None:
-        self.id = id
-        self.source_filename = source_filename
-        self.destination_filename = destination_filename
-        self.project_path = project_path
-        paths = get_paths(project_path)
-        self.schema = pl.DataFrame(
-            orient="row",
-            schema={
-                "ID_STATEMENT": pl.Utf8,
-                "ID_BATCHLINE": pl.Utf8,
-                "ID_ACCOUNT": pl.Utf8,
-                "STD_COMPANY": pl.Utf8,
-                "STD_STATEMENT_TYPE": pl.Utf8,
-                "STD_ACCOUNT": pl.Utf8,
-                "STD_SORTCODE": pl.Utf8,
-                "STD_ACCOUNT_NUMBER": pl.Utf8,
-                "STD_ACCOUNT_HOLDER": pl.Utf8,
-                "STD_STATEMENT_DATE": pl.Date,
-                "STD_OPENING_BALANCE": pl.Decimal(16, 4),
-                "STD_PAYMENTS_IN": pl.Decimal(16, 4),
-                "STD_PAYMENTS_OUT": pl.Decimal(16, 4),
-                "STD_CLOSING_BALANCE": pl.Decimal(16, 4),
-            },
-        )
-        self.key = "ID_STATEMENT"
-        self.records: pl.DataFrame | None = None
-
-        source_default = paths.statement_heads_temp(self.id) if self.id > -1 else paths.statement_heads
-        source_file = _resolve_parquet_file(paths, source_default, source_filename)
-
-        if source_filename is not None:
-            self.records = pl.read_parquet(source_file).drop("index")
-        elif header_results is not None and id_statement is not None:
-            self.records = build_statement_heads_records(
-                self.schema, id_statement, id_batchline, id_account, company, statement_type, account, header_results
-            )
-
-        dest_default = paths.statement_heads_temp(self.id) if self.id > -1 else paths.statement_heads
-        destination_file = _resolve_parquet_file(paths, dest_default, destination_filename)
-
-        super().__init__(destination_file, self.schema, self.records, self.key)
-
-
-class StatementLines(Parquet):
-    __slots__ = ("id", "source_filename", "destination_filename", "project_path")
-
-    def __init__(
-        self,
-        id_statement: str | None = None,
-        lines_results: pl.LazyFrame | None = None,
-        id: int = -1,
-        source_filename: str | None = None,
-        destination_filename: str | None = None,
-        project_path: Path | None = None,
-    ) -> None:
-        self.id = id
-        self.source_filename = source_filename
-        self.destination_filename = destination_filename
-        self.project_path = project_path
-        paths = get_paths(project_path)
-        self.schema = pl.DataFrame(
-            orient="row",
-            schema={
-                "ID_TRANSACTION": pl.Utf8,
-                "ID_STATEMENT": pl.Utf8,
-                "STD_PAGE_NUMBER": pl.Int32,
-                "STD_TRANSACTION_DATE": pl.Date,
-                "STD_TRANSACTION_NUMBER": pl.UInt32,
-                "STD_CD": pl.Utf8,
-                "STD_TRANSACTION_TYPE": pl.Utf8,
-                "STD_TRANSACTION_TYPE_CD": pl.Utf8,
-                "STD_TRANSACTION_DESC": pl.Utf8,
-                "STD_OPENING_BALANCE": pl.Decimal(16, 4),
-                "STD_PAYMENTS_IN": pl.Decimal(16, 4),
-                "STD_PAYMENTS_OUT": pl.Decimal(16, 4),
-                "STD_CLOSING_BALANCE": pl.Decimal(16, 4),
-            },
-        )
-        self.key = "ID_TRANSACTION"
-        self.records: pl.DataFrame | None = None
-
-        source_default = paths.statement_lines_temp(self.id) if self.id > -1 else paths.statement_lines
-        source_file = _resolve_parquet_file(paths, source_default, source_filename)
-
-        if source_filename is not None:
-            self.records = pl.read_parquet(source_file).drop("index")
-        elif lines_results is not None and id_statement is not None:
-            self.records = build_statement_lines_records(self.schema, id_statement, lines_results)
-
-        dest_default = paths.statement_lines_temp(self.id) if self.id > -1 else paths.statement_lines
-        destination_file = _resolve_parquet_file(paths, dest_default, destination_filename)
-
-        super().__init__(destination_file, self.schema, self.records, self.key)
-
-
-class BatchHeads(Parquet):
-    __slots__ = ("destination_filename", "project_path")
-
-    def __init__(
-        self,
-        batch_id: str | None = None,
-        session_id: str | None = None,
-        user_id: str | None = None,
-        path: str | None = None,
-        company_key: str | None = None,
-        account_key: str | None = None,
-        pdf_count: int | None = None,
-        errors: int | None = None,
-        duration_secs: float | None = None,
-        process_time: datetime | None = None,
-        destination_filename: str | None = None,
-        project_path: Path | None = None,
-    ) -> None:
-        self.destination_filename = destination_filename
-        self.project_path = project_path
-        paths = get_paths(project_path)
-        self.schema = pl.DataFrame(
-            orient="row",
-            schema={
-                "ID_BATCH": pl.Utf8,
-                "ID_SESSION": pl.Utf8,
-                "ID_USER": pl.Utf8,
-                "STD_PATH": pl.Utf8,
-                "STD_COMPANY": pl.Utf8,
-                "STD_ACCOUNT": pl.Utf8,
-                "STD_PDF_COUNT": pl.Int64,
-                "STD_ERROR_COUNT": pl.Int64,
-                "STD_DURATION_SECS": pl.Float64,
-                "STD_UPDATETIME": pl.Datetime,
-            },
-        )
-        self.records: pl.DataFrame | None = None
-        if batch_id is not None:
-            self.records = build_batch_heads_records(
-                self.schema,
-                batch_id,
-                session_id or "",
-                user_id or "",
-                path,
-                company_key,
-                account_key,
-                pdf_count,
-                errors,
-                duration_secs,
-                process_time,
-            )
-        self.key = "ID_BATCH"
-        destination_file = _resolve_parquet_file(paths, paths.batch_heads, destination_filename)
-        super().__init__(destination_file, self.schema, self.records, self.key)
-
-
-class BatchLines(Parquet):
-    __slots__ = ("batch_lines", "id", "source_filename", "destination_filename", "project_path")
-
-    def __init__(
-        self,
-        batch_lines: list[dict] | None = None,
-        id: int = -1,
-        source_filename: str | None = None,
-        destination_filename: str | None = None,
-        project_path: Path | None = None,
-    ) -> None:
-        self.batch_lines = batch_lines
-        self.id = id
-        self.source_filename = source_filename
-        self.destination_filename = destination_filename
-        self.project_path = project_path
-        paths = get_paths(project_path)
-        self.schema = pl.DataFrame(
-            orient="row",
-            schema={
-                "ID_BATCH": pl.Utf8,
-                "ID_BATCHLINE": pl.Utf8,
-                "ID_STATEMENT": pl.Utf8,
-                "STD_BATCH_LINE": pl.Int64,
-                "STD_FILENAME": pl.Utf8,
-                "STD_ACCOUNT": pl.Utf8,
-                "STD_DURATION_SECS": pl.Float64,
-                "STD_UPDATETIME": pl.Datetime,
-                "STD_SUCCESS": pl.Boolean,
-                "STD_ERROR_MESSAGE": pl.Utf8,
-                "ERROR_CAB": pl.Boolean,
-                "ERROR_CONFIG": pl.Boolean,
-                "ERROR_DATA": pl.Boolean,
-            },
-        )
-        self.key = "ID_BATCHLINE"
-        self.records: pl.DataFrame | None = None
-
-        source_default = paths.batch_lines_temp(self.id) if self.id > -1 else paths.batch_lines
-        source_file = _resolve_parquet_file(paths, source_default, source_filename)
-
-        if source_filename is not None:
-            self.records = pl.read_parquet(source_file).drop("index")
-        elif self.batch_lines:
-            self.records = build_batch_lines_records(self.schema, self.batch_lines)
-
-        dest_default = paths.batch_lines_temp(self.id) if self.id > -1 else paths.batch_lines
-        destination_file = _resolve_parquet_file(paths, dest_default, destination_filename)
-
-        super().__init__(destination_file, self.schema, self.records, self.key)
-
-
 def update_parquet(
     processed_pdfs: list[BaseException | PdfResult],
     batch_id: str,
@@ -663,14 +640,14 @@ def update_parquet(
     errors: int,
     duration_secs: float,
     process_time: datetime,
-    project_path: Path | None = None,
+    paths: ProjectPaths,
 ) -> float:
     """
     Update parquet files with processed results from all PDFs in a batch.
 
     Iterates through processed PDFs, handles any exceptions, and updates
-    the main parquet files from temporary files created during processing.
-    Also writes batch header metadata. Should be called after all PDFs have
+    the permanent parquet files from temporary files created during processing.
+    Also writes batch header metadata.  Should be called after all PDFs have
     been processed to finalise the batch.
 
     Args:
@@ -689,8 +666,8 @@ def update_parquet(
         errors: Count of failed statement processings.
         duration_secs: Total processing time accumulated so far (seconds).
         process_time: Timestamp when batch processing started.
-        project_path: Optional project root directory for parquet output.
-            If not provided, uses the default project folder.
+        paths: Resolved :class:`~bank_statement_parser.modules.paths.ProjectPaths`
+            instance for this project.
 
     Returns:
         float: Time spent updating parquet files (seconds).
@@ -702,22 +679,22 @@ def update_parquet(
             return 0.0
         elif isinstance(pdf, PdfResult):
             if pdf.batch_lines_stem:
-                bl = BatchLines(source_filename=pdf.batch_lines_stem, project_path=project_path)
+                bl = BatchLines(file=paths.batch_lines, source=paths.parquet / f"{pdf.batch_lines_stem}.parquet")
                 bl.update()
                 bl.cleanup()
                 bl = None
             if pdf.statement_heads_stem:
-                sh = StatementHeads(source_filename=pdf.statement_heads_stem, project_path=project_path)
+                sh = StatementHeads(file=paths.statement_heads, source=paths.parquet / f"{pdf.statement_heads_stem}.parquet")
                 sh.update()
                 sh.cleanup()
                 sh = None
             if pdf.statement_lines_stem:
-                sl = StatementLines(source_filename=pdf.statement_lines_stem, project_path=project_path)
+                sl = StatementLines(file=paths.statement_lines, source=paths.parquet / f"{pdf.statement_lines_stem}.parquet")
                 sl.update()
                 sl.cleanup()
                 sl = None
             if pdf.cab_stem:
-                cb = ChecksAndBalances(source_filename=pdf.cab_stem, project_path=project_path)
+                cb = ChecksAndBalances(file=paths.cab, source=paths.parquet / f"{pdf.cab_stem}.parquet")
                 cb.update()
                 cb.cleanup()
                 cb = None
@@ -726,6 +703,7 @@ def update_parquet(
 
     # Write batch header metadata to parquet
     pq_heads = BatchHeads(
+        file=paths.batch_heads,
         batch_id=batch_id,
         session_id=session_id,
         user_id=user_id,
@@ -736,7 +714,6 @@ def update_parquet(
         errors=errors,
         duration_secs=duration_secs + parquet_secs,
         process_time=process_time,
-        project_path=project_path,
     )
     pq_heads.create()
     pq_heads.cleanup()
@@ -745,12 +722,13 @@ def update_parquet(
     return parquet_secs
 
 
-def main():
-    BatchHeads().truncate()
-    BatchLines().truncate()
-    StatementHeads().truncate()
-    StatementLines().truncate()
-    ...
+def main() -> None:
+    """Truncate all permanent parquet files (dev utility)."""
+    _paths = ProjectPaths.resolve()
+    BatchHeads(file=_paths.batch_heads).truncate()
+    BatchLines(file=_paths.batch_lines).truncate()
+    StatementHeads(file=_paths.statement_heads).truncate()
+    StatementLines(file=_paths.statement_lines).truncate()
 
 
 if __name__ == "__main__":

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -52,7 +52,7 @@ class ProjectPaths:
           log/
             debug/
 
-    Use :func:`get_paths` to obtain an instance rather than instantiating
+    Use :meth:`resolve` to obtain an instance rather than instantiating
     this class directly.
     """
 
@@ -164,37 +164,65 @@ class ProjectPaths:
     # Temporary Parquet files (written per-PDF during batch processing)
     # ------------------------------------------------------------------
 
-    def cab_temp(self, id: int) -> Path:
-        """Temporary checks-and-balances file for PDF at index *id*."""
-        return self.parquet / f"checks_and_balances_temp_{id}.parquet"
+    def cab_temp(self, id: int, batch_id: str) -> Path:
+        """Temporary checks-and-balances file for PDF at index *id* in batch *batch_id*."""
+        return self.parquet / f"checks_and_balances_temp_{batch_id}_{id}.parquet"
 
-    def batch_lines_temp(self, id: int) -> Path:
-        """Temporary batch-lines file for PDF at index *id*."""
-        return self.parquet / f"batch_lines_temp_{id}.parquet"
+    def batch_lines_temp(self, id: int, batch_id: str) -> Path:
+        """Temporary batch-lines file for PDF at index *id* in batch *batch_id*."""
+        return self.parquet / f"batch_lines_temp_{batch_id}_{id}.parquet"
 
-    def statement_heads_temp(self, id: int) -> Path:
-        """Temporary statement-heads file for PDF at index *id*."""
-        return self.parquet / f"statement_heads_temp_{id}.parquet"
+    def statement_heads_temp(self, id: int, batch_id: str) -> Path:
+        """Temporary statement-heads file for PDF at index *id* in batch *batch_id*."""
+        return self.parquet / f"statement_heads_temp_{batch_id}_{id}.parquet"
 
-    def statement_lines_temp(self, id: int) -> Path:
-        """Temporary statement-lines file for PDF at index *id*."""
-        return self.parquet / f"statement_lines_temp_{id}.parquet"
+    def statement_lines_temp(self, id: int, batch_id: str) -> Path:
+        """Temporary statement-lines file for PDF at index *id* in batch *batch_id*."""
+        return self.parquet / f"statement_lines_temp_{batch_id}_{id}.parquet"
 
     # ------------------------------------------------------------------
     # Filename stems (no directory, no extension)
     # ------------------------------------------------------------------
 
-    def cab_temp_stem(self, id: int) -> str:
-        return f"checks_and_balances_temp_{id}"
+    def cab_temp_stem(self, id: int, batch_id: str) -> str:
+        return f"checks_and_balances_temp_{batch_id}_{id}"
 
-    def batch_lines_temp_stem(self, id: int) -> str:
-        return f"batch_lines_temp_{id}"
+    def batch_lines_temp_stem(self, id: int, batch_id: str) -> str:
+        return f"batch_lines_temp_{batch_id}_{id}"
 
-    def statement_heads_temp_stem(self, id: int) -> str:
-        return f"statement_heads_temp_{id}"
+    def statement_heads_temp_stem(self, id: int, batch_id: str) -> str:
+        return f"statement_heads_temp_{batch_id}_{id}"
 
-    def statement_lines_temp_stem(self, id: int) -> str:
-        return f"statement_lines_temp_{id}"
+    def statement_lines_temp_stem(self, id: int, batch_id: str) -> str:
+        return f"statement_lines_temp_{batch_id}_{id}"
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def resolve(cls, project_path: Path | None = None) -> "ProjectPaths":
+        """Return a :class:`ProjectPaths` for *project_path*.
+
+        When *project_path* is ``None``, the default project folder bundled
+        with the package is used (``src/bank_statement_parser/project/``).
+
+        This is a pure path-computation factory.  It does **not** validate
+        that the project directory exists or is correctly structured — call
+        :func:`validate_or_initialise_project` for that (done automatically
+        by :class:`~bank_statement_parser.modules.statements.Statement` and
+        :class:`~bank_statement_parser.modules.statements.StatementBatch`).
+
+        Args:
+            project_path: Root of the project directory tree.  Must follow
+                the standard sub-directory layout (``config/``, ``parquet/``,
+                ``database/``, etc.).  Pass ``None`` to use the default
+                bundled project.
+
+        Returns:
+            A :class:`ProjectPaths` instance with all derived path attributes.
+        """
+        return cls(root=project_path if project_path is not None else _DEFAULT_PROJECT_ROOT)
 
     # ------------------------------------------------------------------
     # Sub-directory validation helpers
@@ -228,54 +256,10 @@ class ProjectPaths:
 
 
 # ---------------------------------------------------------------------------
-# Public factory
-# ---------------------------------------------------------------------------
-
-
-def validate_project_path(project_path: Path) -> None:
-    """
-    Raise :exc:`ProjectFolderNotFound` if *project_path* is not an existing directory.
-
-    Args:
-        project_path: The project root directory to validate.
-
-    Raises:
-        ProjectFolderNotFound: If the path does not exist or is not a directory.
-    """
-    if not project_path.is_dir():
-        raise ProjectFolderNotFound(project_path)
-
-
-def get_paths(project_path: Path | None = None) -> ProjectPaths:
-    """
-    Return a :class:`ProjectPaths` for the given project root.
-
-    When *project_path* is ``None``, the default project folder bundled with
-    the package is used (``src/bank_statement_parser/project/``).
-
-    This is a pure path-computation factory. It does **not** validate that the
-    project directory exists or is correctly structured — use
-    :func:`validate_or_initialise_project` for that (called automatically by
-    :class:`~bank_statement_parser.modules.statements.Statement` and
-    :class:`~bank_statement_parser.modules.statements.StatementBatch`).
-
-    Args:
-        project_path: Root of the project directory tree.  Must follow the
-            standard sub-directory layout (``config/``, ``parquet/``,
-            ``database/``, etc.).
-
-    Returns:
-        A :class:`ProjectPaths` instance with all derived path attributes.
-    """
-    return ProjectPaths(root=project_path if project_path is not None else _DEFAULT_PROJECT_ROOT)
-
-
-# ---------------------------------------------------------------------------
 # Ensure the default project structure exists on first import
 # ---------------------------------------------------------------------------
 
-_default_paths = get_paths()
-_default_paths.ensure_dirs()
+ProjectPaths.resolve().ensure_dirs()
 
 
 # ---------------------------------------------------------------------------
@@ -381,7 +365,7 @@ def validate_or_initialise_project(project_path: Path) -> None:
     if not project_path.is_dir():
         raise ProjectFolderNotFound(project_path)
 
-    paths = ProjectPaths(root=project_path)
+    paths = ProjectPaths.resolve(project_path)
 
     has_toml = paths.config.is_dir() and bool(list(paths.config.rglob("*.toml")))
     has_db = paths.project_db.exists()

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -18,7 +18,7 @@ import polars as pl
 from xlsxwriter import Workbook
 
 from bank_statement_parser.modules.errors import ProjectDatabaseMissing
-from bank_statement_parser.modules.paths import get_paths
+from bank_statement_parser.modules.paths import ProjectPaths
 
 
 def _require_db(paths) -> None:
@@ -96,7 +96,7 @@ def export_csv(
             when ``None``.
     """
     if folder is None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         paths.ensure_subdir_for_write(paths.csv)
         folder = paths.csv
     if type == "full":
@@ -144,7 +144,7 @@ def export_excel(
             when ``None``.
     """
     if path is None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         paths.ensure_subdir_for_write(paths.excel)
         path = paths.excel / "transactions.xlsx"
     with Workbook(str(path)) as wb:
@@ -207,7 +207,7 @@ class FlatTransaction:
     __slots__ = ("all",)
 
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data_filtered(paths.project_db, "FlatTransaction", "FlatTransactionBatch", batch_id)
 
@@ -216,7 +216,7 @@ class FactBalance:
     __slots__ = ("all",)
 
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data_filtered(paths.project_db, "FactBalance", "FactBalanceBatch", batch_id)
 
@@ -225,7 +225,7 @@ class DimTime:
     __slots__ = ("all",)
 
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data_filtered(paths.project_db, "DimTime", "DimTimeBatch", batch_id)
 
@@ -234,7 +234,7 @@ class DimStatement:
     __slots__ = ("all",)
 
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data_filtered(paths.project_db, "DimStatement", "DimStatementBatch", batch_id)
 
@@ -243,7 +243,7 @@ class DimAccount:
     __slots__ = ("all",)
 
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data_filtered(paths.project_db, "DimAccount", "DimAccountBatch", batch_id)
 
@@ -252,7 +252,7 @@ class FactTransaction:
     __slots__ = ("all",)
 
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data_filtered(paths.project_db, "FactTransaction", "FactTransactionBatch", batch_id)
 
@@ -261,7 +261,7 @@ class GapReport:
     __slots__ = ("all", "gaps")
 
     def __init__(self, project_path: Path | None = None) -> None:
-        paths = get_paths(project_path)
+        paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
         self.all = _read_data(paths.project_db, "GapReport")
         self.gaps = self.all.filter(pl.col("gap_flag") == "GAP")
@@ -271,4 +271,4 @@ if __name__ == "__main__":
     pl.Config.set_tbl_rows(100)
     pl.Config.set_tbl_cols(55)
     pl.Config.set_fmt_str_lengths(25)
-    export_excel(get_paths().excel.joinpath("test_db.xlsx"), type="simple")
+    export_excel(ProjectPaths.resolve().excel.joinpath("test_db.xlsx"), type="simple")

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -37,7 +37,7 @@ from bank_statement_parser.modules.config import (
 from bank_statement_parser.modules.data import Account, PdfResult, StandardFields
 from bank_statement_parser.modules.database import update_db
 from bank_statement_parser.modules.parquet import update_parquet
-from bank_statement_parser.modules.paths import get_paths, validate_or_initialise_project
+from bank_statement_parser.modules.paths import ProjectPaths, validate_or_initialise_project
 from bank_statement_parser.modules.pdf_functions import pdf_close, pdf_open
 from bank_statement_parser.modules.statement_functions import get_results, get_standard_fields
 
@@ -204,7 +204,7 @@ class Statement:
         sentinel ``"<PDF ERROR>"`` when it does not.
         """
         if not skip_project_validation:
-            validate_or_initialise_project(get_paths(project_path).root)
+            validate_or_initialise_project(ProjectPaths.resolve(project_path).root)
         self.logs: pl.DataFrame = pl.DataFrame(
             schema={
                 "file_path": pl.Utf8,
@@ -577,7 +577,7 @@ def process_pdf_statement(
             ``error_cab``, ``error_config``, and ``error_data``.  See :data:`PdfResult`
             for full field descriptions.
     """
-    paths = get_paths(project_path)
+    paths = ProjectPaths.resolve(project_path)
     batch_lines_stem: str | None = None
     statement_heads_stem: str | None = None
     statement_lines_stem: str | None = None
@@ -641,6 +641,7 @@ def process_pdf_statement(
             try:
                 # Save extracted header data
                 pq_statement_heads = pq.StatementHeads(
+                    file=paths.statement_heads_temp(idx, batch_id),
                     id_statement=stmt.ID_STATEMENT,
                     id_batchline=batch_line["ID_BATCHLINE"],
                     id_account=stmt.ID_ACCOUNT,
@@ -648,11 +649,9 @@ def process_pdf_statement(
                     statement_type=stmt.statement_type,
                     account=stmt.account,
                     header_results=stmt.header_results,
-                    id=idx,
-                    project_path=project_path,
                 )
                 pq_statement_heads.create()
-                statement_heads_stem = paths.statement_heads_temp_stem(idx)
+                statement_heads_stem = paths.statement_heads_temp_stem(idx, batch_id)
                 pq_statement_heads.cleanup()
                 pq_statement_heads = None
             except Exception as e:
@@ -667,13 +666,12 @@ def process_pdf_statement(
             try:
                 # Save extracted transaction line data
                 pq_statement_lines = pq.StatementLines(
+                    file=paths.statement_lines_temp(idx, batch_id),
                     id_statement=stmt.ID_STATEMENT,
                     lines_results=stmt.lines_results,
-                    id=idx,
-                    project_path=project_path,
                 )
                 pq_statement_lines.create()
-                statement_lines_stem = paths.statement_lines_temp_stem(idx)
+                statement_lines_stem = paths.statement_lines_temp_stem(idx, batch_id)
                 pq_statement_lines.cleanup()
                 pq_statement_lines = None
             except Exception as e:
@@ -691,14 +689,13 @@ def process_pdf_statement(
         if not stmt.checks_and_balances.is_empty():
             try:
                 pq_cab = pq.ChecksAndBalances(
+                    file=paths.cab_temp(idx, batch_id),
                     id_statement=stmt.ID_STATEMENT,
                     id_batch=stmt.ID_BATCH,
                     checks_and_balances=stmt.checks_and_balances,
-                    id=idx,
-                    project_path=project_path,
                 )
                 pq_cab.create()
-                cab_stem = paths.cab_temp_stem(idx)
+                cab_stem = paths.cab_temp_stem(idx, batch_id)
                 pq_cab.cleanup()
                 pq_cab = None
             except Exception as e:
@@ -732,9 +729,9 @@ def process_pdf_statement(
     batch_line["STD_UPDATETIME"] = datetime.now()
 
     # Save batch line data
-    pq_batch_lines = pq.BatchLines(batch_lines=[batch_line], id=idx, project_path=project_path)
+    pq_batch_lines = pq.BatchLines(file=paths.batch_lines_temp(idx, batch_id), batch_lines=[batch_line])
     pq_batch_lines.create()
-    batch_lines_stem = paths.batch_lines_temp_stem(idx)
+    batch_lines_stem = paths.batch_lines_temp_stem(idx, batch_id)
     pq_batch_lines.cleanup()
     pq_batch_lines = None
 
@@ -769,7 +766,7 @@ def delete_temp_files(
         project_path: Optional project root directory used to resolve stems
             to full paths.
     """
-    paths = get_paths(project_path)
+    paths = ProjectPaths.resolve(project_path)
     for pdf in processed_pdfs:
         if isinstance(pdf, BaseException):
             return None
@@ -815,7 +812,7 @@ def copy_statements_to_project(
     Returns:
         List of :class:`~pathlib.Path` objects for every file that was copied.
     """
-    paths = get_paths(project_path)
+    paths = ProjectPaths.resolve(project_path)
     copied: list[Path] = []
     for entry in processed_pdfs:
         if not isinstance(entry, PdfResult):
@@ -928,7 +925,7 @@ class StatementBatch:
         copy_statements_to_project() after processing.
         """
         if not skip_project_validation:
-            validate_or_initialise_project(get_paths(project_path).root)
+            validate_or_initialise_project(ProjectPaths.resolve(project_path).root)
         print("processing...")
         self.process_time: datetime = datetime.now()
         self.timer_start = time()
@@ -1132,7 +1129,7 @@ class StatementBatch:
                 errors=self.errors,
                 duration_secs=self.duration_secs,
                 process_time=self.process_time,
-                project_path=resolved,
+                paths=ProjectPaths.resolve(resolved),
             )
             self.duration_secs += self.parquet_secs
         if datadestination in ("database", "both"):

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -37,7 +37,7 @@ import polars as pl
 
 from bank_statement_parser.modules import reports_db as db
 from bank_statement_parser.modules.data import PdfResult
-from bank_statement_parser.modules.paths import get_paths
+from bank_statement_parser.modules.paths import ProjectPaths
 from bank_statement_parser.modules.statements import copy_statements_to_project
 
 FLOAT_TOL = 0.005  # monetary comparison tolerance (matches test_datamart.py)
@@ -59,20 +59,20 @@ class TestGoodStatements:
 
     def test_parquet_files_exist(self, good_project):
         """statement_heads, statement_lines and batch_lines parquet files are written."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         assert paths.statement_heads.exists(), "statement_heads.parquet missing"
         assert paths.statement_lines.exists(), "statement_lines.parquet missing"
         assert paths.batch_lines.exists(), "batch_lines.parquet missing"
 
     def test_db_exists(self, good_project):
         """SQLite project.db is created and non-empty."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         assert paths.project_db.exists(), "project.db missing"
         assert paths.project_db.stat().st_size > 0, "project.db is empty"
 
     def test_no_temp_files_remain(self, good_project):
         """No *_temp_*.parquet files survive after delete_temp_files()."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         temp_files = list(paths.parquet.glob("*_temp_*.parquet"))
         assert temp_files == [], f"Temp files still present: {temp_files}"
 
@@ -102,7 +102,7 @@ class TestDbReports:
 
     def test_fact_transaction_row_count(self, good_project):
         """DB FactTransaction row count matches SQLite statement_lines table."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         with sqlite3.connect(paths.project_db) as conn:
             raw_count = conn.execute("SELECT COUNT(*) FROM statement_lines").fetchone()[0]
         ft = db.FactTransaction(project_path=good_project.project_path).all.collect()
@@ -130,7 +130,7 @@ class TestDbReports:
 
     def test_statement_lines_db_value_in_matches_fact_transaction_db(self, good_project):
         """SUM(STD_PAYMENTS_IN) from SQLite statement_lines equals DB FactTransaction value_in sum."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         with sqlite3.connect(paths.project_db) as conn:
             raw_sum = conn.execute("SELECT SUM(CAST(STD_PAYMENTS_IN AS REAL)) FROM statement_lines").fetchone()[0]
         ft_sum = db.FactTransaction(project_path=good_project.project_path).all.collect()["value_in"].sum()
@@ -138,7 +138,7 @@ class TestDbReports:
 
     def test_statement_lines_db_value_out_matches_fact_transaction_db(self, good_project):
         """SUM(STD_PAYMENTS_OUT) from SQLite statement_lines equals DB FactTransaction value_out sum."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         with sqlite3.connect(paths.project_db) as conn:
             raw_sum = conn.execute("SELECT SUM(CAST(STD_PAYMENTS_OUT AS REAL)) FROM statement_lines").fetchone()[0]
         ft_sum = db.FactTransaction(project_path=good_project.project_path).all.collect()["value_out"].sum()
@@ -146,7 +146,7 @@ class TestDbReports:
 
     def test_statement_lines_row_count_matches_db(self, good_project):
         """Raw statement_lines row count agrees between parquet file and SQLite table."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         pq_count = pl.read_parquet(paths.statement_lines).height
         with sqlite3.connect(paths.project_db) as conn:
             db_count = conn.execute("SELECT COUNT(*) FROM statement_lines").fetchone()[0]
@@ -178,7 +178,7 @@ class TestExports:
     def test_db_export_csv_full(self, good_project):
         """DB export_csv(type='full') writes all six CSV files."""
         db.export_csv(type="full", project_path=good_project.project_path)
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         for name in _FULL_CSV_FILES:
             f = paths.csv / name
             assert f.exists(), f"Missing CSV: {name}"
@@ -187,7 +187,7 @@ class TestExports:
     def test_db_export_csv_simple(self, good_project):
         """DB export_csv(type='simple') writes the flat transactions CSV."""
         db.export_csv(type="simple", project_path=good_project.project_path)
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         f = paths.csv / "transactions_table.csv"
         assert f.exists(), "Missing transactions_table.csv (db/simple)"
         assert f.stat().st_size > 0, "Empty transactions_table.csv (db/simple)"
@@ -199,7 +199,7 @@ class TestExports:
     def test_db_export_excel_full(self, good_project):
         """DB export_excel(type='full') writes a non-empty workbook."""
         db.export_excel(type="full", project_path=good_project.project_path)
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         f = paths.excel / "transactions.xlsx"
         assert f.exists(), "Missing transactions.xlsx (db/full)"
         assert f.stat().st_size > 0, "Empty transactions.xlsx (db/full)"
@@ -207,7 +207,7 @@ class TestExports:
     def test_db_export_excel_simple(self, good_project):
         """DB export_excel(type='simple') writes a non-empty workbook."""
         db.export_excel(type="simple", project_path=good_project.project_path)
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         f = paths.excel / "transactions.xlsx"
         assert f.exists(), "Missing transactions.xlsx (db/simple)"
         assert f.stat().st_size > 0, "Empty transactions.xlsx (db/simple)"
@@ -219,7 +219,7 @@ class TestExports:
     def test_batch_export_both(self, good_project):
         """StatementBatch.export(filetype='both') writes both Excel and CSV."""
         good_project.batch.export(filetype="both", type="full")
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         # Excel file must exist
         xlsx = paths.excel / "transactions.xlsx"
         assert xlsx.exists(), "Missing transactions.xlsx after filetype='both'"
@@ -258,7 +258,7 @@ class TestCopyStatements:
 
     def test_directory_structure(self, good_project):
         """Copied files land under statements/<year>/<id_account>/<filename>."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         copied = good_project.batch.copy_statements_to_project()
         for dest in copied:
             # dest must be inside <project>/statements/
@@ -325,7 +325,7 @@ class TestBatchReports:
 
     def _get_batch_id(self, good_project) -> str:
         """Return the first batch ID from the database."""
-        paths = get_paths(good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
         with sqlite3.connect(paths.project_db) as conn:
             row = conn.execute("SELECT ID_BATCH FROM batch_heads ORDER BY STD_UPDATETIME LIMIT 1").fetchone()
         assert row is not None, "No batch_heads rows found — cannot test batch filtering"


### PR DESCRIPTION
instead of calling paths helpers all over the place to resolve the source and destination of files and databases, we resolve once for the current project and pass through where required also, the parquet classes and functions have been refactored to the filepaths are passed to them by calling functions, rather than having to receive and resolve full paths finally, the temporary parquet filenames now include the current batch_id to prevent overwriting under race conditions