### PR TITLE
feat: add REVIEW outcome, STD_REVIEW_COUNT, and strip CAB from debug

### DIFF
--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -75,9 +75,41 @@ Insert processed batch results into the SQLite database.
 
 ## Data structures
 
-### `bsp.PdfResult()`
+### `bsp.PdfResult`
 
-*function* — `bank_statement_parser.modules.data`
+*class* — `bank_statement_parser.modules.data`
+
+Top-level result returned by :func:`~bank_statement_parser.modules.statements.process_pdf_statement`.
+
+### `bsp.Success`
+
+*class* — `bank_statement_parser.modules.data`
+
+Payload for a fully-validated PDF result.
+
+### `bsp.Review`
+
+*class* — `bank_statement_parser.modules.data`
+
+Payload for a PDF where extraction succeeded but CAB validation failed.
+
+### `bsp.Failure`
+
+*class* — `bank_statement_parser.modules.data`
+
+Payload for a PDF result where no usable statement data was produced.
+
+### `bsp.StatementInfo`
+
+*class* — `bank_statement_parser.modules.data`
+
+Statement-level metadata extracted from a successfully validated PDF.
+
+### `bsp.ParquetFiles`
+
+*class* — `bank_statement_parser.modules.data`
+
+Paths to the statement-level temporary Parquet files written on the SUCCESS path.
 
 ## Debug / diagnostics
 

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -87,7 +87,7 @@ from bank_statement_parser.modules.parquet import update_parquet
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
-from bank_statement_parser.modules.data import PdfResult
+from bank_statement_parser.modules.data import Failure, ParquetFiles, PdfResult, Review, StatementInfo, Success
 
 # ---------------------------------------------------------------------------
 # Debug / diagnostics
@@ -147,6 +147,11 @@ __all__ = [
     "update_db",
     # Data structures
     "PdfResult",
+    "Success",
+    "Review",
+    "Failure",
+    "StatementInfo",
+    "ParquetFiles",
     # Debug / diagnostics
     "debug_pdf_statement",
     "debug_statements",

--- a/src/bank_statement_parser/data/create_project_db.py
+++ b/src/bank_statement_parser/data/create_project_db.py
@@ -6,7 +6,7 @@ from bank_statement_parser.data.create_project_db_views import create_views
 SCHEMAS = {
     "checks_and_balances": {
         "ID_CAB": "TEXT",
-        "ID_STATEMENT": "TEXT",
+        "ID_BATCHLINE": "TEXT",
         "ID_BATCH": "TEXT",
         "HAS_TRANSACTIONS": "INTEGER",
         "STD_OPENING_BALANCE_HEADS": "REAL",
@@ -64,6 +64,7 @@ SCHEMAS = {
         "STD_ACCOUNT": "TEXT",
         "STD_PDF_COUNT": "INTEGER",
         "STD_ERROR_COUNT": "INTEGER",
+        "STD_REVIEW_COUNT": "INTEGER",
         "STD_DURATION_SECS": "REAL",
         "STD_UPDATETIME": "TEXT",
     },
@@ -86,7 +87,7 @@ SCHEMAS = {
 
 FOREIGN_KEYS = {
     "checks_and_balances": [
-        "FOREIGN KEY (ID_STATEMENT) REFERENCES statement_heads(ID_STATEMENT) ON UPDATE CASCADE ON DELETE CASCADE",
+        "FOREIGN KEY (ID_BATCHLINE) REFERENCES batch_lines(ID_BATCHLINE) ON UPDATE CASCADE ON DELETE CASCADE",
         "FOREIGN KEY (ID_BATCH) REFERENCES batch_heads(ID_BATCH) ON UPDATE CASCADE ON DELETE CASCADE",
     ],
     "statement_heads": [
@@ -97,7 +98,6 @@ FOREIGN_KEYS = {
     ],
     "batch_lines": [
         "FOREIGN KEY (ID_BATCH) REFERENCES batch_heads(ID_BATCH) ON UPDATE CASCADE ON DELETE CASCADE",
-        "FOREIGN KEY (ID_STATEMENT) REFERENCES statement_heads(ID_STATEMENT) ON UPDATE CASCADE ON DELETE CASCADE",
     ],
 }
 
@@ -137,7 +137,7 @@ def main(db_path: Path, with_fk: bool = False):
     if with_fk:
         conn.execute("PRAGMA foreign_keys = ON;")
 
-    table_order = ["batch_heads", "statement_heads", "checks_and_balances", "statement_lines", "batch_lines"]
+    table_order = ["batch_heads", "batch_lines", "statement_heads", "checks_and_balances", "statement_lines"]
 
     for table_name in table_order:
         create_table(conn, table_name, SCHEMAS[table_name], with_fk)
@@ -164,6 +164,7 @@ def create_indexes(db_path: Path):
         "CREATE INDEX IF NOT EXISTS idx_batch_lines_id_statement ON batch_lines(ID_STATEMENT)",
         "CREATE INDEX IF NOT EXISTS idx_sh_stmt_acct ON statement_heads(ID_STATEMENT, ID_ACCOUNT)",
         "CREATE INDEX IF NOT EXISTS idx_batch_lines_stmt_batch ON batch_lines(ID_STATEMENT, ID_BATCH)",
+        "CREATE INDEX IF NOT EXISTS idx_cab_id_batchline ON checks_and_balances(ID_BATCHLINE)",
     ]
 
     for idx_sql in indexes:

--- a/src/bank_statement_parser/data/housekeeping.py
+++ b/src/bank_statement_parser/data/housekeeping.py
@@ -5,12 +5,11 @@ from pathlib import Path
 
 class Housekeeping:
     FK_RELATIONSHIPS = [
-        ("checks_and_balances", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
+        ("checks_and_balances", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
         ("checks_and_balances", "ID_BATCH", "batch_heads", "ID_BATCH"),
         ("statement_heads", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
         ("statement_lines", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
         ("batch_lines", "ID_BATCH", "batch_heads", "ID_BATCH"),
-        ("batch_lines", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
     ]
 
     DELETE_ORDER = [
@@ -27,23 +26,21 @@ class Housekeeping:
         [
             rel[0]
             for rel in [
-                ("checks_and_balances", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
+                ("checks_and_balances", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
                 ("checks_and_balances", "ID_BATCH", "batch_heads", "ID_BATCH"),
                 ("statement_heads", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
                 ("statement_lines", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
                 ("batch_lines", "ID_BATCH", "batch_heads", "ID_BATCH"),
-                ("batch_lines", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
             ]
         ]
         + [
             rel[2]
             for rel in [
-                ("checks_and_balances", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
+                ("checks_and_balances", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
                 ("checks_and_balances", "ID_BATCH", "batch_heads", "ID_BATCH"),
                 ("statement_heads", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
                 ("statement_lines", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
                 ("batch_lines", "ID_BATCH", "batch_heads", "ID_BATCH"),
-                ("batch_lines", "ID_STATEMENT", "statement_heads", "ID_STATEMENT"),
             ]
         ]
     )

--- a/src/bank_statement_parser/data/mock_project_data.py
+++ b/src/bank_statement_parser/data/mock_project_data.py
@@ -72,6 +72,7 @@ def generate_mock_data(db_path: Path, num_batches: int = 10, statements_per_batc
                 account_types[i % len(account_types)],
                 statements_per_batch,
                 0,
+                0,
                 random.uniform(10.0, 60.0),
                 batch_dates[i],
             )
@@ -214,7 +215,7 @@ def generate_mock_data(db_path: Path, num_batches: int = 10, statements_per_batc
 
     checks_and_balances_data = []
     for i, statement_id in enumerate(statement_ids):
-        cab_id = str(uuid.uuid4())
+        batchline_id = batchline_ids[i]
         batch_idx = batch_assignment[i]
 
         cursor.execute("SELECT SUM(STD_PAYMENTS_IN), SUM(STD_PAYMENTS_OUT) FROM statement_lines WHERE ID_STATEMENT = ?", (statement_id,))
@@ -222,8 +223,8 @@ def generate_mock_data(db_path: Path, num_batches: int = 10, statements_per_batc
 
         checks_and_balances_data.append(
             (
-                cab_id,
-                statement_id,
+                batchline_id,
+                batchline_id,
                 batch_ids[batch_idx],
                 1,
                 statement_heads_data[i][10],
@@ -247,13 +248,13 @@ def generate_mock_data(db_path: Path, num_batches: int = 10, statements_per_batc
         )
 
     cursor.executemany(
-        "INSERT INTO checks_and_balances (ID_CAB, ID_STATEMENT, ID_BATCH, HAS_TRANSACTIONS, STD_OPENING_BALANCE_HEADS, STD_PAYMENTS_IN_HEADS, STD_PAYMENTS_OUT_HEADS, STD_MOVEMENT_HEADS, STD_CLOSING_BALANCE_HEADS, STD_OPENING_BALANCE_LINES, STD_PAYMENTS_IN_LINES, STD_PAYMENTS_OUT_LINES, STD_MOVEMENT_LINES, STD_CLOSING_BALANCE_LINES, CHECK_PAYMENTS_IN, CHECK_PAYMENTS_OUT, CHECK_MOVEMENT, CHECK_CLOSING) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO checks_and_balances (ID_CAB, ID_BATCHLINE, ID_BATCH, HAS_TRANSACTIONS, STD_OPENING_BALANCE_HEADS, STD_PAYMENTS_IN_HEADS, STD_PAYMENTS_OUT_HEADS, STD_MOVEMENT_HEADS, STD_CLOSING_BALANCE_HEADS, STD_OPENING_BALANCE_LINES, STD_PAYMENTS_IN_LINES, STD_PAYMENTS_OUT_LINES, STD_MOVEMENT_LINES, STD_CLOSING_BALANCE_LINES, CHECK_PAYMENTS_IN, CHECK_PAYMENTS_OUT, CHECK_MOVEMENT, CHECK_CLOSING) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         checks_and_balances_data,
     )
     print(f"Inserted {len(checks_and_balances_data)} checks_and_balances")
 
     cursor.executemany(
-        "INSERT INTO batch_heads (ID_BATCH, ID_SESSION, ID_USER, STD_PATH, STD_COMPANY, STD_ACCOUNT, STD_PDF_COUNT, STD_ERROR_COUNT, STD_DURATION_SECS, STD_UPDATETIME) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO batch_heads (ID_BATCH, ID_SESSION, ID_USER, STD_PATH, STD_COMPANY, STD_ACCOUNT, STD_PDF_COUNT, STD_ERROR_COUNT, STD_REVIEW_COUNT, STD_DURATION_SECS, STD_UPDATETIME) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         batch_heads_data,
     )
     print(f"Inserted {len(batch_heads_data)} batch_heads (written last as in production)")

--- a/src/bank_statement_parser/modules/__init__.py
+++ b/src/bank_statement_parser/modules/__init__.py
@@ -4,7 +4,9 @@ Public interface for the bank_statement_parser.modules sub-package.
 Flat exports (imported directly):
     Statement, StatementBatch           -- PDF parsing / batch processing
     process_pdf_statement               -- process a single PDF (module-level)
-    PdfResult                           -- namedtuple returned by process_pdf_statement
+    PdfResult                           -- dataclass returned by process_pdf_statement
+    Success, Review, Failure            -- result payload dataclasses
+    StatementInfo, ParquetFiles         -- typed sub-fields of Success / Review
     delete_temp_files                   -- clean up temp parquet files
     StatementError                      -- root of the exception hierarchy
     pdf_open, page_crop, page_text,
@@ -24,7 +26,7 @@ functions.  Access them via the namespace:
 import bank_statement_parser.modules.reports_db as db
 from bank_statement_parser.modules.config import copy_default_config
 from bank_statement_parser.modules.paths import copy_project_folders
-from bank_statement_parser.modules.data import PdfResult
+from bank_statement_parser.modules.data import Failure, ParquetFiles, PdfResult, Review, StatementInfo, Success
 from bank_statement_parser.modules.errors import StatementError
 from bank_statement_parser.modules.pdf_functions import get_table_from_region, page_crop, page_text, pdf_open, region_search
 from bank_statement_parser.modules.statements import (
@@ -40,6 +42,11 @@ __all__ = [
     "StatementBatch",
     "process_pdf_statement",
     "PdfResult",
+    "Success",
+    "Review",
+    "Failure",
+    "StatementInfo",
+    "ParquetFiles",
     "delete_temp_files",
     # Config helpers
     "copy_default_config",

--- a/src/bank_statement_parser/modules/data.py
+++ b/src/bank_statement_parser/modules/data.py
@@ -1,8 +1,32 @@
-"""Dataclasses and named tuples used throughout the bank_statement_parser pipeline.
+"""Dataclasses used throughout the bank_statement_parser pipeline.
 
-These structures are the primary vehicle for typed configuration: TOML files are
-loaded by ``dacite`` directly into these dataclasses, so every field name here
-corresponds to a key in one of the project TOML files.
+Two distinct categories of dataclass live here:
+
+**Pipeline result types** — returned by :func:`~bank_statement_parser.modules.statements.process_pdf_statement`
+and consumed by downstream persistence, debug, and test code:
+
+* :class:`StatementInfo` — statement-level metadata extracted from a successfully
+  parsed PDF (account, date, balances, canonical rename target).
+* :class:`ParquetFiles` — full :class:`~pathlib.Path` objects for the two
+  statement-level temporary Parquet files (``statement_heads``, ``statement_lines``).
+  Only populated on the ``SUCCESS`` path.
+* :class:`Success` — groups ``StatementInfo`` + ``ParquetFiles`` for a
+  fully-validated result.
+* :class:`Review` — groups ``StatementInfo`` + ``ParquetFiles`` for a statement
+  where extraction succeeded but checks-and-balances validation failed.  Carries
+  the CAB error message and detail so the caller can decide whether to accept the
+  data after human review.
+* :class:`Failure` — carries the error message, error type, and optional detail
+  for any failure mode where no usable statement data was produced.
+* :class:`PdfResult` — top-level result returned by
+  :func:`~bank_statement_parser.modules.statements.process_pdf_statement`.
+  Always present; carries ``result`` (``"SUCCESS"`` / ``"REVIEW"`` / ``"FAILURE"``),
+  ``outcome`` (the specific outcome label), ``batch_lines`` (always written),
+  ``checks_and_balances`` (written for SUCCESS and REVIEW), and ``payload``
+  (the concrete :class:`Success`, :class:`Review`, or :class:`Failure` instance).
+
+**Configuration types** — loaded from TOML files by ``dacite`` into dataclasses.
+Every field name here corresponds to a key in one of the project TOML files.
 
 Annotation convention
 ---------------------
@@ -14,82 +38,234 @@ Each field comment is prefixed with one of:
                  implementation and should not be relied upon.
 """
 
-from collections import namedtuple
 from dataclasses import dataclass
-from typing import Optional
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Literal, Optional
 
 
-PdfResult = namedtuple(
-    "PdfResult",
-    [
-        "batch_lines_stem",  # str | None — temp parquet stem for batch_lines
-        "statement_heads_stem",  # str | None — temp parquet stem for statement_heads
-        "statement_lines_stem",  # str | None — temp parquet stem for statement_lines
-        "cab_stem",  # str | None — temp parquet stem for checks_and_balances
-        "file_src",  # str | None — absolute path of the source PDF
-        "file_dst",  # str | None — canonical rename target basename
-        "error_cab",  # bool — True if checks & balances validation failed
-        "error_config",  # bool — True if configuration or parsing failed
-        "error_data",  # bool — True if parquet schema/data failure occurred
-        # --- lightweight summary fields (new) ---
-        "id_statement",  # str | None — SHA512 statement identifier
-        "id_account",  # str | None — compound account identifier
-        "account",  # str | None — human-readable account name
-        "statement_date",  # date | None — statement date from header
-        "payments_in",  # Decimal | None — total payments in from checks & balances
-        "payments_out",  # Decimal | None — total payments out from checks & balances
-        "opening_balance",  # Decimal | None — opening balance from header
-        "closing_balance",  # Decimal | None — closing balance from header
-        "error_message",  # str | None — combined error message text
-    ],
-)
-"""Named tuple returned by :func:`~bank_statement_parser.modules.statements.process_pdf_statement`
-for each processed PDF.
+@dataclass(frozen=True, slots=True)
+class StatementInfo:
+    """Statement-level metadata extracted from a successfully validated PDF.
 
-Fields
-------
-batch_lines_stem:
-    Filename stem of the temporary batch-lines parquet file, or ``None`` on failure.
-statement_heads_stem:
-    Filename stem of the temporary statement-heads parquet file, or ``None`` on failure.
-statement_lines_stem:
-    Filename stem of the temporary statement-lines parquet file, or ``None`` on failure.
-cab_stem:
-    Filename stem of the temporary checks-and-balances parquet file, or ``None`` on failure.
-file_src:
-    Absolute path string of the original PDF, or ``None`` on failure.
-file_dst:
-    Target basename (``{id_account}_{YYYYMMDD}.pdf``) for the project copy, or ``None`` if
-    the statement did not produce a rename target.
-error_cab:
-    ``True`` if checks & balances validation failed.
-error_config:
-    ``True`` if a configuration or parsing failure occurred.
-error_data:
-    ``True`` if a parquet schema or data-type mismatch failure occurred during
-    the ``.extend()`` step (e.g. a ``String`` value where a ``Date`` was expected).
-id_statement:
-    SHA512-based unique identifier for the statement, or ``None`` on failure.
-id_account:
-    Compound account identifier (``{company_key}_{account_type_key}_{account_number}``),
-    or ``None`` if the statement failed or no config matched.
-account:
-    Human-readable account name from config (e.g. ``"Current Account"``),
-    or ``None`` on failure.
-statement_date:
-    Statement date extracted from the header, or ``None`` on failure.
-payments_in:
-    Total payments in (Decimal) from checks & balances, or ``None`` on failure.
-payments_out:
-    Total payments out (Decimal) from checks & balances, or ``None`` on failure.
-opening_balance:
-    Opening balance (Decimal) from the statement header, or ``None`` on failure.
-closing_balance:
-    Closing balance (Decimal) from the statement header, or ``None`` on failure.
-error_message:
-    Combined error message string accumulated during processing,
-    or ``None`` / empty string when processing succeeded.
-"""
+    Populated once per statement on the success path in
+    :func:`~bank_statement_parser.modules.statements.process_pdf_statement`.
+    All fields are non-optional; a ``StatementInfo`` is only constructed when
+    extraction and checks-and-balances validation both pass.
+
+    Attributes:
+        id_statement: SHA512 hex digest of the first-page text, used as a
+            unique, content-addressable identifier for the statement.
+        id_account: Compound account identifier in the form
+            ``{company_key}_{account_type_key}_{account_number}`` (spaces
+            stripped from the account number).
+        account: Human-readable account name from config
+            (e.g. ``"Current Account"``).
+        statement_date: Statement date extracted from the PDF header.
+        payments_in: Total payments-in figure stated on the statement, as
+            extracted by the checks-and-balances pass.
+        payments_out: Total payments-out figure stated on the statement.
+        opening_balance: Opening balance from the statement header.
+        closing_balance: Closing balance from the statement header.
+        filename_new: Canonical rename target basename for the source PDF in
+            the form ``{id_account}_{YYYYMMDD}.pdf``.
+    """
+
+    id_statement: str
+    id_account: str
+    account: str
+    statement_date: date
+    payments_in: Decimal
+    payments_out: Decimal
+    opening_balance: Decimal
+    closing_balance: Decimal
+    filename_new: str
+
+
+@dataclass(frozen=True, slots=True)
+class ParquetFiles:
+    """Paths to the statement-level temporary Parquet files written on the SUCCESS path.
+
+    Each field holds the absolute :class:`~pathlib.Path` of a temporary file
+    written by :func:`~bank_statement_parser.modules.statements.process_pdf_statement`,
+    or ``None`` when the corresponding write was skipped due to a data error.
+
+    ``batch_lines`` and ``checks_and_balances`` are written for more than just
+    ``SUCCESS`` results and therefore live directly on :class:`PdfResult` rather
+    than here.
+
+    These paths are consumed by
+    :func:`~bank_statement_parser.modules.parquet.update_parquet` and
+    :func:`~bank_statement_parser.modules.database.update_db` to merge the
+    temporary files into the permanent store, and by
+    :func:`~bank_statement_parser.modules.statements.delete_temp_files` to
+    clean them up afterwards.
+
+    Attributes:
+        statement_heads: Path to the temporary ``statement_heads`` Parquet file,
+            or ``None`` if not written.
+        statement_lines: Path to the temporary ``statement_lines`` Parquet file,
+            or ``None`` if not written.
+    """
+
+    statement_heads: Path | None
+    statement_lines: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class Success:
+    """Payload for a fully-validated PDF result.
+
+    Constructed only when both extraction and checks-and-balances validation
+    succeed.  Groups the statement metadata and the temporary Parquet file
+    paths into a single object carried by :class:`PdfResult`.
+
+    Attributes:
+        statement_info: Statement-level metadata (account, date, balances,
+            rename target).
+        parquet_files: Paths to the two statement-level temporary Parquet files
+            (``statement_heads``, ``statement_lines``) written during processing.
+    """
+
+    statement_info: StatementInfo
+    parquet_files: ParquetFiles
+
+
+@dataclass(frozen=True, slots=True)
+class Review:
+    """Payload for a PDF where extraction succeeded but CAB validation failed.
+
+    Constructed when statement data was fully extracted and written to Parquet
+    but the checks-and-balances validation step found a discrepancy.  The
+    caller must decide — after human review — whether to accept or discard the
+    data.  The statement data is **not** automatically merged into the
+    permanent store.
+
+    Attributes:
+        statement_info: Statement-level metadata (account, date, balances,
+            rename target).  Populated even though CAB failed.
+        parquet_files: Paths to the two statement-level temporary Parquet files
+            (``statement_heads``, ``statement_lines``) written during processing.
+        message: Primary human-readable CAB error message
+            (e.g. ``"** Checks & Balances Failure ** ..."``).
+        message_detail: Per-check delta lines produced by ``_cab_detail``.
+            Empty string when not applicable.
+    """
+
+    statement_info: StatementInfo
+    parquet_files: ParquetFiles
+    message: str
+    message_detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Failure:
+    """Payload for a PDF result where no usable statement data was produced.
+
+    A single ``Failure`` type covers all non-recoverable failure modes; the
+    specific mode is encoded in ``error_type`` rather than through subclasses,
+    which avoids ``__slots__`` inheritance conflicts under ``frozen=True``.
+
+    Note that CAB failures no longer use this class — they produce a
+    :class:`Review` payload instead, because the statement data *was*
+    extracted and *may* be usable after human review.
+
+    Attributes:
+        message: Primary human-readable error message accumulated during
+            processing.
+        error_type: Short string identifying the failure category:
+
+            * ``"config"`` — a configuration or PDF-parsing failure occurred
+              before or during extraction.
+            * ``"data"``   — extraction passed but a Parquet schema/data-type
+              error occurred during the write step.
+            * ``"other"``  — an unexpected exception was caught by the
+              last-resort guard in ``process_pdf_statement``.
+
+        message_detail: Optional supplementary detail appended to ``message``.
+            Empty string when not applicable.
+    """
+
+    message: str
+    error_type: Literal["config", "data", "other"]
+    message_detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class PdfResult:
+    """Top-level result returned by :func:`~bank_statement_parser.modules.statements.process_pdf_statement`.
+
+    Every call to ``process_pdf_statement`` returns exactly one ``PdfResult``
+    regardless of whether processing succeeded or failed.  The ``result``
+    sentinel provides fast top-level discrimination; ``outcome`` carries the
+    specific outcome label; ``batch_lines`` and ``checks_and_balances`` carry
+    the paths to always-written and conditionally-written audit files; and
+    ``payload`` is the fully-typed result object.
+
+    Typical usage
+    -------------
+    Check ``result`` first, then access the typed payload::
+
+        pdf_result: PdfResult = process_pdf_statement(...)
+
+        if pdf_result.result == "SUCCESS":
+            info = pdf_result.payload.statement_info
+            pq   = pdf_result.payload.parquet_files
+            print(info.id_account, info.statement_date)
+        elif pdf_result.result == "REVIEW":
+            review = pdf_result.payload
+            print("CAB failed:", review.message)
+            # review.parquet_files holds the written statement data
+        else:
+            failure = pdf_result.payload
+            print(failure.error_type, failure.message)
+
+    For bulk processing via :class:`~bank_statement_parser.modules.statements.StatementBatch`,
+    iterate ``batch.processed_pdfs`` which is typed as
+    ``list[BaseException | PdfResult]``::
+
+        for entry in batch.processed_pdfs:
+            if isinstance(entry, BaseException):
+                continue          # unhandled worker crash
+            if entry.result == "FAILURE":
+                print(entry.payload.message)
+
+    Attributes:
+        result: Top-level outcome sentinel — ``"SUCCESS"``, ``"REVIEW"``, or
+            ``"FAILURE"``.  Use this for fast branching before inspecting
+            ``payload``.
+        outcome: Specific outcome label — one of:
+
+            * ``"SUCCESS"``        — extraction and validation passed.
+            * ``"REVIEW CAB"``     — extraction succeeded but CAB validation
+              failed; data needs human review before acceptance.
+            * ``"FAILURE CONFIG"`` — configuration / PDF-parsing failure.
+            * ``"FAILURE DATA"``   — Parquet write failure during extraction.
+            * ``"FAILURE OTHER"``  — unexpected exception (last-resort guard).
+
+        batch_lines: Path to the temporary ``batch_lines`` Parquet file.
+            Always written regardless of outcome.
+        checks_and_balances: Path to the temporary ``checks_and_balances``
+            Parquet file, or ``None`` if the CAB step did not run (i.e. a
+            ``FAILURE CONFIG`` or ``FAILURE OTHER`` result where
+            ``Statement.__init__`` never completed).
+        payload: The concrete result object — a :class:`Success` on the
+            success path, a :class:`Review` when CAB validation failed, or a
+            :class:`Failure` on any non-recoverable failure path.
+            Use ``isinstance(payload, Success)`` or check ``result`` before
+            accessing type-specific attributes.
+
+    See also
+    --------
+    :class:`Success`, :class:`Review`, :class:`Failure`, :class:`StatementInfo`, :class:`ParquetFiles`
+    """
+
+    result: Literal["SUCCESS", "REVIEW", "FAILURE"]
+    outcome: Literal["SUCCESS", "REVIEW CAB", "FAILURE CONFIG", "FAILURE DATA", "FAILURE OTHER"]
+    batch_lines: Path
+    checks_and_balances: Path | None
+    payload: "Success | Review | Failure"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bank_statement_parser/modules/database.py
+++ b/src/bank_statement_parser/modules/database.py
@@ -13,7 +13,7 @@ from time import time
 import polars as pl
 
 from bank_statement_parser.data.build_datamart import build_datamart, _ensure_mart_structure
-from bank_statement_parser.modules.data import PdfResult
+from bank_statement_parser.modules.data import PdfResult, Success
 from bank_statement_parser.modules.errors import ProjectDatabaseMissing
 from bank_statement_parser.modules.paths import ProjectPaths
 
@@ -43,6 +43,7 @@ _MIGRATIONS: list[tuple[str, str, str, str]] = [
     ("batch_lines", "ERROR_DATA", "INTEGER", "0"),
     ("batch_heads", "ID_SESSION", "TEXT", "''"),
     ("batch_heads", "ID_USER", "TEXT", "''"),
+    ("batch_heads", "STD_REVIEW_COUNT", "INTEGER", "0"),
 ]
 
 # Views that may be absent from databases created before they were introduced.
@@ -323,6 +324,7 @@ def update_db(
     account_key: str | None,
     pdf_count: int,
     errors: int,
+    reviews: int,
     duration_secs: float,
     process_time: datetime,
     project_path: Path | None = None,
@@ -349,6 +351,7 @@ def update_db(
         account_key: Optional account identifier used for this batch.
         pdf_count: Total number of PDFs in the batch.
         errors: Count of failed statement processings.
+        reviews: Count of REVIEW (CAB-failed) statement processings.
         duration_secs: Total processing time accumulated so far (seconds).
         process_time: Timestamp when batch processing started.
         project_path: Optional project root directory path.
@@ -394,30 +397,27 @@ def update_db(
             conn.close()
             return 0.0
         elif isinstance(pdf, PdfResult):
-            if pdf.batch_lines_stem:
-                batch = paths.parquet / f"{pdf.batch_lines_stem}.parquet"
-                if batch.exists():
-                    df = pl.read_parquet(batch)
-                    _insert_df(df, "batch_lines")
-                    batch.unlink()
-            if pdf.statement_heads_stem:
-                head = paths.parquet / f"{pdf.statement_heads_stem}.parquet"
-                if head.exists():
-                    df = pl.read_parquet(head)
+            # batch_lines is always present on PdfResult
+            if pdf.batch_lines and pdf.batch_lines.exists():
+                df = pl.read_parquet(pdf.batch_lines)
+                _insert_df(df, "batch_lines")
+                pdf.batch_lines.unlink()
+            # checks_and_balances is present for SUCCESS and REVIEW
+            if pdf.checks_and_balances and pdf.checks_and_balances.exists():
+                df = pl.read_parquet(pdf.checks_and_balances)
+                _insert_df(df, "checks_and_balances")
+                pdf.checks_and_balances.unlink()
+            # statement_heads and statement_lines are only inserted for SUCCESS
+            if pdf.result == "SUCCESS" and isinstance(pdf.payload, Success):
+                pq_files = pdf.payload.parquet_files
+                if pq_files.statement_heads and pq_files.statement_heads.exists():
+                    df = pl.read_parquet(pq_files.statement_heads)
                     _insert_df(df, "statement_heads")
-                    head.unlink()
-            if pdf.statement_lines_stem:
-                lines = paths.parquet / f"{pdf.statement_lines_stem}.parquet"
-                if lines.exists():
-                    df = pl.read_parquet(lines)
+                    pq_files.statement_heads.unlink()
+                if pq_files.statement_lines and pq_files.statement_lines.exists():
+                    df = pl.read_parquet(pq_files.statement_lines)
                     _insert_df(df, "statement_lines")
-                    lines.unlink()
-            if pdf.cab_stem:
-                cab = paths.parquet / f"{pdf.cab_stem}.parquet"
-                if cab.exists():
-                    df = pl.read_parquet(cab)
-                    _insert_df(df, "checks_and_balances")
-                    cab.unlink()
+                    pq_files.statement_lines.unlink()
 
     db_secs = time() - update_start
 
@@ -431,6 +431,7 @@ def update_db(
             "STD_ACCOUNT": [account_key],
             "STD_PDF_COUNT": [pdf_count],
             "STD_ERROR_COUNT": [errors],
+            "STD_REVIEW_COUNT": [reviews],
             "STD_DURATION_SECS": [duration_secs + db_secs],
             "STD_UPDATETIME": [process_time.isoformat()],
         }
@@ -441,7 +442,7 @@ def update_db(
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     conn.close()
 
-    if pdf_count > errors:  # if all pdf statements have failed no point in re-building the datamart
+    if pdf_count > (errors + reviews):  # if all pdf statements have failed/are under review no point in re-building the datamart
         try:
             build_datamart(db_path=db_path)
         except Exception as e:

--- a/src/bank_statement_parser/modules/debug.py
+++ b/src/bank_statement_parser/modules/debug.py
@@ -3,8 +3,8 @@ Diagnostic debug module for bank statement processing failures.
 
 This module provides functions to re-process failing bank statement PDFs and
 capture diagnostic information — raw page text, full extraction results
-(including failures), checks & balances data, and error details — into a
-structured JSON file.  No parquet or database writes are performed.
+(including failures), and error details — into a structured JSON file.
+No parquet or database writes are performed.
 
 Functions:
     debug_pdf_statement: Re-process a single failing PDF and write a debug.json.
@@ -21,11 +21,6 @@ from pathlib import Path
 import polars as pl
 
 from bank_statement_parser.modules.data import PdfResult
-from bank_statement_parser.modules.parquet import (
-    _build_checks_and_balances_data,
-    _build_statement_heads_data,
-    _build_statement_lines_data,
-)
 from bank_statement_parser.modules.paths import ProjectPaths
 from bank_statement_parser.modules.statement_functions import get_results
 
@@ -40,286 +35,6 @@ def _suppress_stdout():
             yield
         finally:
             sys.stdout = old_stdout
-
-
-def _cab_detail_rows(cab: pl.DataFrame) -> list[dict]:
-    """
-    Build a list of dicts describing each failing checks & balances row.
-
-    For each of the four balance checks that is False, appends a dict with the
-    check name, stated value, extracted value, and delta (where applicable).
-
-    Args:
-        cab: The ``checks_and_balances`` DataFrame from a :class:`Statement`.
-
-    Returns:
-        A list of dicts, one per failing check, or an empty list if cab is
-        empty or all checks pass.
-    """
-    if cab.is_empty():
-        return []
-    row = cab.row(0, named=True)
-    failing: list[dict] = []
-    if not row.get("BAL_PAYMENTS_IN", True):
-        stated = row["STD_PAYMENTS_IN"]
-        extracted = row["STD_PAYMENT_IN"]
-        failing.append(
-            {
-                "check": "BAL_PAYMENTS_IN",
-                "stated": stated,
-                "extracted": extracted,
-                "delta": round(float(stated) - float(extracted), 2),
-            }
-        )
-    if not row.get("BAL_PAYMENTS_OUT", True):
-        stated = row["STD_PAYMENTS_OUT"]
-        extracted = row["STD_PAYMENT_OUT"]
-        failing.append(
-            {
-                "check": "BAL_PAYMENTS_OUT",
-                "stated": stated,
-                "extracted": extracted,
-                "delta": round(float(stated) - float(extracted), 2),
-            }
-        )
-    if not row.get("BAL_MOVEMENT", True):
-        failing.append(
-            {
-                "check": "BAL_MOVEMENT",
-                "statement_movement": row["STD_STATEMENT_MOVEMENT"],
-                "extracted_movement": row["STD_MOVEMENT"],
-                "balance_of_payments": row["STD_BALANCE_OF_PAYMENTS"],
-            }
-        )
-    if not row.get("BAL_CLOSING", True):
-        stated = row["STD_CLOSING_BALANCE"]
-        calculated = row["STD_RUNNING_BALANCE"]
-        failing.append(
-            {
-                "check": "BAL_CLOSING",
-                "stated": stated,
-                "calculated": calculated,
-                "delta": round(float(stated) - float(calculated), 2),
-            }
-        )
-    return failing
-
-
-def _diagnose_parquet_schemas(
-    stmt: object,
-) -> list[dict]:
-    """
-    Attempt each parquet data-build step and capture diagnostics on failure.
-
-    This is the *expensive* diagnostic step that only runs inside the debug
-    path.  For each of the three per-statement parquet classes
-    (ChecksAndBalances, StatementHeads, StatementLines) the corresponding
-    ``_build_*_data()`` helper is called to produce the intermediate data
-    DataFrame, then ``.extend()`` is attempted against the expected schema.
-    If the call raises a :class:`polars.exceptions.SchemaError` (or any other
-    exception), a diagnostic dict is captured containing:
-
-    - ``parquet_class``: Which parquet class failed.
-    - ``error``: The exception message.
-    - ``expected_schema``: Column-name -> dtype mapping from the empty schema.
-    - ``actual_dtypes``: Column-name -> dtype mapping of the data that was
-      produced *before* the ``.extend()`` call.  ``None`` if the data could
-      not be built at all.
-    - ``mismatched_columns``: List of ``{"column", "expected", "actual"}``
-      dicts for every column whose dtype differs.
-    - ``data_sample``: First 5 rows of the actual data as a list of dicts,
-      or ``None``.
-
-    Only classes whose data-build or ``.extend()`` call fails are included.
-    An empty list means all three classes would succeed (i.e. the original
-    failure was transient or environment-specific).
-
-    Args:
-        stmt: A :class:`~bank_statement_parser.modules.statements.Statement`
-            instance that has already been fully constructed (header_results,
-            lines_results, and checks_and_balances populated).  Typed as
-            ``object`` to avoid a circular import.
-
-    Returns:
-        A list of diagnostic dicts, one per failing parquet class.
-    """
-    # Schemas are defined inline to match the class constructors exactly,
-    # avoiding Parquet I/O or project-path resolution.
-    diagnostics: list[dict] = []
-
-    # --- ChecksAndBalances ---
-    cab_schema = pl.DataFrame(
-        orient="row",
-        schema={
-            "ID_CAB": pl.Utf8,
-            "ID_STATEMENT": pl.Utf8,
-            "ID_BATCH": pl.Utf8,
-            "HAS_TRANSACTIONS": pl.Boolean,
-            "STD_OPENING_BALANCE_HEADS": pl.Decimal(16, 4),
-            "STD_PAYMENTS_IN_HEADS": pl.Decimal(16, 4),
-            "STD_PAYMENTS_OUT_HEADS": pl.Decimal(16, 4),
-            "STD_MOVEMENT_HEADS": pl.Decimal(16, 4),
-            "STD_CLOSING_BALANCE_HEADS": pl.Decimal(16, 4),
-            "STD_OPENING_BALANCE_LINES": pl.Decimal(16, 4),
-            "STD_PAYMENTS_IN_LINES": pl.Decimal(16, 4),
-            "STD_PAYMENTS_OUT_LINES": pl.Decimal(16, 4),
-            "STD_MOVEMENT_LINES": pl.Decimal(16, 4),
-            "STD_CLOSING_BALANCE_LINES": pl.Decimal(16, 4),
-            "CHECK_PAYMENTS_IN": pl.Boolean,
-            "CHECK_PAYMENTS_OUT": pl.Boolean,
-            "CHECK_MOVEMENT": pl.Boolean,
-            "CHECK_CLOSING": pl.Boolean,
-        },
-    )
-    _run_build_diagnostic(
-        diagnostics,
-        "ChecksAndBalances",
-        cab_schema,
-        _build_checks_and_balances_data,
-        stmt.ID_STATEMENT,  # type: ignore[attr-defined]
-        stmt.ID_BATCH or "",  # type: ignore[attr-defined]
-        stmt.checks_and_balances,  # type: ignore[attr-defined]
-    )
-
-    # --- StatementHeads ---
-    heads_schema = pl.DataFrame(
-        orient="row",
-        schema={
-            "ID_STATEMENT": pl.Utf8,
-            "ID_BATCHLINE": pl.Utf8,
-            "ID_ACCOUNT": pl.Utf8,
-            "STD_COMPANY": pl.Utf8,
-            "STD_STATEMENT_TYPE": pl.Utf8,
-            "STD_ACCOUNT": pl.Utf8,
-            "STD_SORTCODE": pl.Utf8,
-            "STD_ACCOUNT_NUMBER": pl.Utf8,
-            "STD_ACCOUNT_HOLDER": pl.Utf8,
-            "STD_STATEMENT_DATE": pl.Date,
-            "STD_OPENING_BALANCE": pl.Decimal(16, 4),
-            "STD_PAYMENTS_IN": pl.Decimal(16, 4),
-            "STD_PAYMENTS_OUT": pl.Decimal(16, 4),
-            "STD_CLOSING_BALANCE": pl.Decimal(16, 4),
-        },
-    )
-    _run_build_diagnostic(
-        diagnostics,
-        "StatementHeads",
-        heads_schema,
-        _build_statement_heads_data,
-        stmt.ID_STATEMENT,  # type: ignore[attr-defined]
-        "DEBUG",  # id_batchline placeholder — not available on Statement
-        stmt.ID_ACCOUNT,  # type: ignore[attr-defined]
-        stmt.company,  # type: ignore[attr-defined]
-        stmt.statement_type,  # type: ignore[attr-defined]
-        stmt.account,  # type: ignore[attr-defined]
-        stmt.header_results,  # type: ignore[attr-defined]
-    )
-
-    # --- StatementLines ---
-    lines_schema = pl.DataFrame(
-        orient="row",
-        schema={
-            "ID_TRANSACTION": pl.Utf8,
-            "ID_STATEMENT": pl.Utf8,
-            "STD_PAGE_NUMBER": pl.Int32,
-            "STD_TRANSACTION_DATE": pl.Date,
-            "STD_TRANSACTION_NUMBER": pl.UInt32,
-            "STD_CD": pl.Utf8,
-            "STD_TRANSACTION_TYPE": pl.Utf8,
-            "STD_TRANSACTION_TYPE_CD": pl.Utf8,
-            "STD_TRANSACTION_DESC": pl.Utf8,
-            "STD_OPENING_BALANCE": pl.Decimal(16, 4),
-            "STD_PAYMENTS_IN": pl.Decimal(16, 4),
-            "STD_PAYMENTS_OUT": pl.Decimal(16, 4),
-            "STD_CLOSING_BALANCE": pl.Decimal(16, 4),
-        },
-    )
-    _run_build_diagnostic(
-        diagnostics,
-        "StatementLines",
-        lines_schema,
-        _build_statement_lines_data,
-        stmt.ID_STATEMENT,  # type: ignore[attr-defined]
-        stmt.lines_results,  # type: ignore[attr-defined]
-    )
-
-    return diagnostics
-
-
-def _run_build_diagnostic(
-    diagnostics: list[dict],
-    class_name: str,
-    schema: pl.DataFrame,
-    data_fn: object,
-    *args: object,
-) -> None:
-    """
-    Build intermediate data via *data_fn*, attempt ``.extend()``, and capture diagnostics on failure.
-
-    Two-phase approach:
-
-    1. Call *data_fn* with *args* to produce the raw data DataFrame (this is
-       the step *before* ``.extend()``).  If this step itself fails, we still
-       capture the exception but ``actual_dtypes`` and ``data_sample`` will
-       be ``None``.
-    2. Attempt ``schema.clone().extend(data)`` to reproduce the exact failure
-       that occurs in the batch path.  If this succeeds, the class is healthy
-       and nothing is appended.
-
-    Args:
-        diagnostics: The accumulator list to append to on failure.
-        class_name: Human-readable class name for the diagnostic entry.
-        schema: The expected schema DataFrame (used to report expected dtypes).
-        data_fn: One of the ``_build_*_data()`` functions from
-            :mod:`~bank_statement_parser.modules.parquet`.
-        *args: Positional arguments forwarded to *data_fn*.
-    """
-    expected = {col: str(dtype) for col, dtype in schema.schema.items()}
-    actual_dtypes: dict[str, str] | None = None
-    data_sample: list[dict] | None = None
-    data: pl.DataFrame | None = None
-
-    # Phase 1: build the intermediate data DataFrame
-    try:
-        data = data_fn(*args)  # type: ignore[operator]
-        actual_dtypes = {col: str(dtype) for col, dtype in data.schema.items()}
-        data_sample = data.head(5).to_dicts()
-    except Exception as exc:
-        # Data construction itself failed — record and return
-        diagnostics.append(
-            {
-                "parquet_class": class_name,
-                "error": f"data construction failed: {exc}",
-                "error_type": type(exc).__qualname__,
-                "expected_schema": expected,
-                "actual_dtypes": None,
-                "mismatched_columns": [],
-                "data_sample": None,
-            }
-        )
-        return
-
-    # Phase 2: attempt .extend() to reproduce the schema mismatch
-    try:
-        schema.clone().extend(data)
-    except Exception as exc:
-        mismatched: list[dict] = []
-        for col, exp_dtype in expected.items():
-            act_dtype = actual_dtypes.get(col)
-            if act_dtype is not None and act_dtype != exp_dtype:
-                mismatched.append({"column": col, "expected": exp_dtype, "actual": act_dtype})
-
-        diagnostics.append(
-            {
-                "parquet_class": class_name,
-                "error": str(exc),
-                "error_type": type(exc).__qualname__,
-                "expected_schema": expected,
-                "actual_dtypes": actual_dtypes,
-                "mismatched_columns": mismatched,
-                "data_sample": data_sample,
-            }
-        )
 
 
 def debug_pdf_statement(
@@ -338,11 +53,7 @@ def debug_pdf_statement(
     - Raw page text for every page (from pdfplumber ``chars``).
     - Full extraction results for header and lines sections with ``scope="all"``,
       so both successful and failing field extractions are visible.
-    - The checks & balances DataFrame (may be empty if processing failed before
-      the validation step ran).
     - The error message and error type.
-    - Parquet schema diagnostics — each ``build_*_records()`` call is replayed
-      and any schema mismatches are captured with expected vs actual dtypes.
 
     The output is written to::
 
@@ -427,13 +138,7 @@ def debug_pdf_statement(
                     lines_debug.extend(collector)
 
             # ----------------------------------------------------------------
-            # 3. Checks & balances — capture before cleanup
-            # ----------------------------------------------------------------
-            cab_rows: list[dict] = stmt.checks_and_balances.to_dicts()
-            cab_failing: list[dict] = _cab_detail_rows(stmt.checks_and_balances)
-
-            # ----------------------------------------------------------------
-            # 4. Error classification
+            # 3. Error classification
             # ----------------------------------------------------------------
             if stmt.error_message:
                 error_type = "ERROR_CONFIG"
@@ -449,17 +154,12 @@ def debug_pdf_statement(
                 error_message = "** Data Failure ** (statement re-processed successfully; original failure was during parquet write)"
             error_detail: dict | None = stmt.error_detail
 
-            # ----------------------------------------------------------------
-            # 5. Parquet schema diagnostics — expensive, debug-path only
-            # ----------------------------------------------------------------
-            parquet_diagnostics: list[dict] = _diagnose_parquet_schemas(stmt)
-
             id_statement = stmt.ID_STATEMENT
             stmt.cleanup()
             stmt = None  # type: ignore[assignment]
 
         # ----------------------------------------------------------------
-        # 6. Write debug.json
+        # 4. Write debug.json
         # ----------------------------------------------------------------
         paths = ProjectPaths.resolve(project_path)
         folder_name = f"{pdf.parent.name}_{pdf.name}"
@@ -478,9 +178,6 @@ def debug_pdf_statement(
                 "debug_timestamp": datetime.now().isoformat(timespec="seconds"),
             },
             "error_detail": error_detail,
-            "parquet_diagnostics": parquet_diagnostics,
-            "checks_and_balances": cab_rows,
-            "checks_and_balances_failing": cab_failing,
             "header_extraction": header_rows,
             "header_debug": header_debug,
             "lines_extraction": lines_rows,
@@ -507,11 +204,14 @@ def debug_statements(
     """
     Re-process all failing statements from a completed batch and write debug files.
 
-    Iterates through the batch results and, for each entry that carries an
-    ``error_cab`` or ``error_config`` flag, calls :func:`debug_pdf_statement`
-    to re-process the PDF and write a diagnostic JSON file.  The run is always
-    sequential regardless of whether the original batch used turbo mode, since
-    failing sets are typically small.
+    Iterates through the batch results and, for each entry whose
+    ``result == "FAILURE"``, calls :func:`debug_pdf_statement` to re-process
+    the PDF and write a diagnostic JSON file.  The run is always sequential
+    regardless of whether the original batch used turbo mode, since failing
+    sets are typically small.
+
+    Pairing between source PDFs and results is done by index: ``pdfs[i]``
+    is the source file for ``processed_pdfs[i]``.
 
     No parquet or database writes are performed.
 
@@ -520,7 +220,8 @@ def debug_statements(
             entries (or :class:`BaseException` for fatal worker errors) as returned
             by the batch processing step.
         pdfs: The original list of PDF :class:`~pathlib.Path` objects passed to the
-            batch.  Used to resolve ``PdfResult.file_src`` back to a ``Path``.
+            batch, in the same order.  ``pdfs[i]`` is the source for
+            ``processed_pdfs[i]``.
         batch_id: The batch identifier from the original run.
         company_key: Optional company identifier used for the original batch.
         account_key: Optional account identifier used for the original batch.
@@ -529,20 +230,11 @@ def debug_statements(
     Returns:
         int: Number of debug JSON files successfully written.
     """
-    # Build a lookup from absolute path string → Path object so we can resolve
-    # PdfResult.file_src (an absolute path string) back to the original Path.
-    pdf_lookup: dict[str, Path] = {str(p.absolute()): p for p in pdfs}
-
     count = 0
-    for entry in processed_pdfs:
+    for entry, pdf_path in zip(processed_pdfs, pdfs):
         if not isinstance(entry, PdfResult):
             continue
-        if not (entry.error_cab or entry.error_config or entry.error_data):
-            continue
-        if entry.file_src is None:
-            continue
-        pdf_path = pdf_lookup.get(entry.file_src)
-        if pdf_path is None:
+        if entry.result != "FAILURE":
             continue
         result = debug_pdf_statement(
             pdf=pdf_path,

--- a/src/bank_statement_parser/modules/parquet.py
+++ b/src/bank_statement_parser/modules/parquet.py
@@ -22,7 +22,7 @@ from time import time
 
 import polars as pl
 
-from bank_statement_parser.modules.data import PdfResult
+from bank_statement_parser.modules.data import PdfResult, Success
 from bank_statement_parser.modules.paths import ProjectPaths
 
 
@@ -101,8 +101,8 @@ class ChecksAndBalances(Parquet):
             When provided, records are loaded from *source* rather than built
             from the data arguments.  When omitted, *file* is used as the
             source when reading existing data (via the base class).
-        id_statement: Unique statement identifier (required when building
-            records from raw data).
+        id_batchline: Batch-line identifier (required when building records
+            from raw data).
         id_batch: Batch identifier (required when building records from raw
             data).
         checks_and_balances: Raw checks-and-balances DataFrame from
@@ -116,7 +116,7 @@ class ChecksAndBalances(Parquet):
         self,
         file: Path,
         source: Path | None = None,
-        id_statement: str | None = None,
+        id_batchline: str | None = None,
         id_batch: str | None = None,
         checks_and_balances: pl.DataFrame | None = None,
     ) -> None:
@@ -124,7 +124,7 @@ class ChecksAndBalances(Parquet):
             orient="row",
             schema={
                 "ID_CAB": pl.Utf8,
-                "ID_STATEMENT": pl.Utf8,
+                "ID_BATCHLINE": pl.Utf8,
                 "ID_BATCH": pl.Utf8,
                 "HAS_TRANSACTIONS": pl.Boolean,
                 "STD_OPENING_BALANCE_HEADS": pl.Decimal(16, 4),
@@ -148,8 +148,8 @@ class ChecksAndBalances(Parquet):
 
         if source is not None:
             self.records = _load_source(source)
-        elif checks_and_balances is not None and id_statement is not None and id_batch is not None:
-            self.records = build_checks_and_balances_records(self.schema, id_statement, id_batch, checks_and_balances)
+        elif checks_and_balances is not None and id_batchline is not None and id_batch is not None:
+            self.records = build_checks_and_balances_records(self.schema, id_batchline, id_batch, checks_and_balances)
 
         super().__init__(file, self.schema, self.records, self.key)
 
@@ -276,6 +276,7 @@ class BatchHeads(Parquet):
         account_key: Account identifier.
         pdf_count: Total number of PDFs in the batch.
         errors: Count of failed statement processings.
+        reviews: Count of REVIEW (CAB-failed) statement processings.
         duration_secs: Total processing time (seconds).
         process_time: Timestamp when batch processing started.
     """
@@ -293,6 +294,7 @@ class BatchHeads(Parquet):
         account_key: str | None = None,
         pdf_count: int | None = None,
         errors: int | None = None,
+        reviews: int | None = None,
         duration_secs: float | None = None,
         process_time: datetime | None = None,
     ) -> None:
@@ -307,6 +309,7 @@ class BatchHeads(Parquet):
                 "STD_ACCOUNT": pl.Utf8,
                 "STD_PDF_COUNT": pl.Int64,
                 "STD_ERROR_COUNT": pl.Int64,
+                "STD_REVIEW_COUNT": pl.Int64,
                 "STD_DURATION_SECS": pl.Float64,
                 "STD_UPDATETIME": pl.Datetime,
             },
@@ -323,6 +326,7 @@ class BatchHeads(Parquet):
                 account_key,
                 pdf_count,
                 errors,
+                reviews,
                 duration_secs,
                 process_time,
             )
@@ -377,14 +381,14 @@ class BatchLines(Parquet):
 
 
 def _build_checks_and_balances_data(
-    id_statement: str,
+    id_batchline: str,
     id_batch: str,
     checks_and_balances: pl.DataFrame,
 ) -> pl.DataFrame:
     """Build the data DataFrame for ChecksAndBalances (without extending the schema).
 
     Args:
-        id_statement: Unique statement identifier.
+        id_batchline: Batch-line identifier.
         id_batch: Batch identifier.
         checks_and_balances: The raw checks & balances DataFrame from
             :class:`~bank_statement_parser.modules.statements.Statement`.
@@ -393,8 +397,8 @@ def _build_checks_and_balances_data(
         A single-row DataFrame with the ChecksAndBalances columns.
     """
     return checks_and_balances.select(
-        ID_CAB=pl.lit(id_statement).add(pl.lit(".").add(pl.lit(id_batch))),
-        ID_STATEMENT=pl.lit(id_statement),
+        ID_CAB=pl.lit(id_batchline),
+        ID_BATCHLINE=pl.lit(id_batchline),
         ID_BATCH=pl.lit(id_batch),
         HAS_TRANSACTIONS=~pl.col("ZERO_TRANSACTION_STATEMENT"),
         STD_OPENING_BALANCE_HEADS="STD_OPENING_BALANCE",
@@ -416,7 +420,7 @@ def _build_checks_and_balances_data(
 
 def build_checks_and_balances_records(
     schema: pl.DataFrame,
-    id_statement: str,
+    id_batchline: str,
     id_batch: str,
     checks_and_balances: pl.DataFrame,
 ) -> pl.DataFrame:
@@ -425,7 +429,7 @@ def build_checks_and_balances_records(
     Args:
         schema: Empty DataFrame with the correct column types (from
             ``ChecksAndBalances.schema``).
-        id_statement: Unique statement identifier.
+        id_batchline: Batch-line identifier.
         id_batch: Batch identifier.
         checks_and_balances: The raw checks & balances DataFrame from
             :class:`~bank_statement_parser.modules.statements.Statement`.
@@ -433,7 +437,7 @@ def build_checks_and_balances_records(
     Returns:
         A single-row DataFrame matching *schema* ready for ``.extend()``.
     """
-    return schema.clone().extend(_build_checks_and_balances_data(id_statement, id_batch, checks_and_balances))
+    return schema.clone().extend(_build_checks_and_balances_data(id_batchline, id_batch, checks_and_balances))
 
 
 def _build_statement_heads_data(
@@ -571,6 +575,7 @@ def build_batch_heads_records(
     account_key: str | None,
     pdf_count: int | None,
     errors: int | None,
+    reviews: int | None,
     duration_secs: float | None,
     process_time: datetime | None,
 ) -> pl.DataFrame:
@@ -587,6 +592,7 @@ def build_batch_heads_records(
         account_key: Account identifier.
         pdf_count: Total number of PDFs in the batch.
         errors: Count of failed statement processings.
+        reviews: Count of REVIEW (CAB-failed) statement processings.
         duration_secs: Total processing time (seconds).
         process_time: Timestamp when batch processing started.
 
@@ -604,6 +610,7 @@ def build_batch_heads_records(
                 "STD_ACCOUNT": account_key,
                 "STD_PDF_COUNT": pdf_count,
                 "STD_ERROR_COUNT": errors,
+                "STD_REVIEW_COUNT": reviews,
                 "STD_DURATION_SECS": duration_secs,
                 "STD_UPDATETIME": process_time,
             },
@@ -638,6 +645,7 @@ def update_parquet(
     account_key: str | None,
     pdf_count: int,
     errors: int,
+    reviews: int,
     duration_secs: float,
     process_time: datetime,
     paths: ProjectPaths,
@@ -664,6 +672,7 @@ def update_parquet(
         account_key: Optional account identifier used for this batch.
         pdf_count: Total number of PDFs in the batch.
         errors: Count of failed statement processings.
+        reviews: Count of REVIEW (CAB-failed) statement processings.
         duration_secs: Total processing time accumulated so far (seconds).
         process_time: Timestamp when batch processing started.
         paths: Resolved :class:`~bank_statement_parser.modules.paths.ProjectPaths`
@@ -678,26 +687,31 @@ def update_parquet(
         if isinstance(pdf, BaseException):
             return 0.0
         elif isinstance(pdf, PdfResult):
-            if pdf.batch_lines_stem:
-                bl = BatchLines(file=paths.batch_lines, source=paths.parquet / f"{pdf.batch_lines_stem}.parquet")
+            # batch_lines is always present on PdfResult
+            if pdf.batch_lines:
+                bl = BatchLines(file=paths.batch_lines, source=pdf.batch_lines)
                 bl.update()
                 bl.cleanup()
                 bl = None
-            if pdf.statement_heads_stem:
-                sh = StatementHeads(file=paths.statement_heads, source=paths.parquet / f"{pdf.statement_heads_stem}.parquet")
-                sh.update()
-                sh.cleanup()
-                sh = None
-            if pdf.statement_lines_stem:
-                sl = StatementLines(file=paths.statement_lines, source=paths.parquet / f"{pdf.statement_lines_stem}.parquet")
-                sl.update()
-                sl.cleanup()
-                sl = None
-            if pdf.cab_stem:
-                cb = ChecksAndBalances(file=paths.cab, source=paths.parquet / f"{pdf.cab_stem}.parquet")
+            # checks_and_balances is present for SUCCESS and REVIEW
+            if pdf.checks_and_balances:
+                cb = ChecksAndBalances(file=paths.cab, source=pdf.checks_and_balances)
                 cb.update()
                 cb.cleanup()
                 cb = None
+            # statement_heads and statement_lines are only merged for SUCCESS
+            if pdf.result == "SUCCESS" and isinstance(pdf.payload, Success):
+                pq_files = pdf.payload.parquet_files
+                if pq_files.statement_heads:
+                    sh = StatementHeads(file=paths.statement_heads, source=pq_files.statement_heads)
+                    sh.update()
+                    sh.cleanup()
+                    sh = None
+                if pq_files.statement_lines:
+                    sl = StatementLines(file=paths.statement_lines, source=pq_files.statement_lines)
+                    sl.update()
+                    sl.cleanup()
+                    sl = None
 
     parquet_secs = time() - update_start
 
@@ -712,6 +726,7 @@ def update_parquet(
         account_key=account_key,
         pdf_count=pdf_count,
         errors=errors,
+        reviews=reviews,
         duration_secs=duration_secs + parquet_secs,
         process_time=process_time,
     )

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -34,7 +34,16 @@ from bank_statement_parser.modules.config import (
     get_config_from_company,
     get_config_from_statement,
 )
-from bank_statement_parser.modules.data import Account, PdfResult, StandardFields
+from bank_statement_parser.modules.data import (
+    Account,
+    Failure,
+    ParquetFiles,
+    PdfResult,
+    Review,
+    StandardFields,
+    StatementInfo,
+    Success,
+)
 from bank_statement_parser.modules.database import update_db
 from bank_statement_parser.modules.parquet import update_parquet
 from bank_statement_parser.modules.paths import ProjectPaths, validate_or_initialise_project
@@ -326,15 +335,17 @@ class Statement:
                 )
             self.logs.rechunk()
             self.success = self.is_successfull()
-            if self.success:
-                if self.config:
-                    # Collect header once; use it for ID, rename target, and summary scalars.
-                    _hdr = self.header_results.select(
-                        "STD_ACCOUNT_NUMBER",
-                        "STD_STATEMENT_DATE",
-                        "STD_OPENING_BALANCE",
-                        "STD_CLOSING_BALANCE",
-                    ).collect()
+            if self.config:
+                # Collect header once; use it for ID, rename target, and summary scalars.
+                # Populated for both SUCCESS and REVIEW (CAB failure) paths — scalar fields
+                # must be available whenever extraction succeeded, regardless of CAB outcome.
+                _hdr = self.header_results.select(
+                    "STD_ACCOUNT_NUMBER",
+                    "STD_STATEMENT_DATE",
+                    "STD_OPENING_BALANCE",
+                    "STD_CLOSING_BALANCE",
+                ).collect()
+                if _hdr.height > 0:
                     acct_number = str(_hdr["STD_ACCOUNT_NUMBER"][0]).replace(" ", "")
                     self.ID_ACCOUNT = f"{self.config.company_key}_{self.config.account_type_key}_{acct_number}"
                     # Always populate the canonical rename target for use by copy_statements_to_project
@@ -560,7 +571,6 @@ def _cab_detail(cab: pl.DataFrame) -> str:
 
 
 def process_pdf_statement(
-    idx: int,
     pdf: Path,
     batch_id: str,
     session_id: str,
@@ -568,16 +578,20 @@ def process_pdf_statement(
     company_key: str | None,
     account_key: str | None,
     project_path: Path | None,
+    idx: int = 0,
     skip_project_validation: bool = False,
 ) -> PdfResult:
     """
     Process a single bank statement PDF and save results to parquet files.
 
     This standalone function handles the complete processing workflow for one PDF:
-    1. Creates a Statement object to parse the PDF
-    2. Extracts header and line data
-    3. Saves results to parquet files (temp files keyed by *idx*)
-    4. Cleans up resources
+
+    1. Creates a :class:`Statement` object to parse the PDF.
+    2. Extracts header and line data.
+    3. Saves results to temporary Parquet files (keyed by *idx*).
+    4. Cleans up resources.
+    5. Returns a :class:`~bank_statement_parser.modules.data.PdfResult` that
+       discriminates success from failure and carries all typed metadata.
 
     File copying to the project ``statements/`` directory is handled separately
     via :func:`copy_statements_to_project`, which operates on the full list of
@@ -594,34 +608,38 @@ def process_pdf_statement(
         company_key: Optional company identifier for config lookup.
         account_key: Optional account identifier for config lookup.
         project_path: Optional project root directory.
-        skip_project_validation: If True, skip the project validation / initialisation
-            step inside ``Statement.__init__``.  Pass ``True`` when this function is
-            called from ``StatementBatch``, which already validated the project once.
+        skip_project_validation: If True, skip the project validation /
+            initialisation step inside ``Statement.__init__``.  Pass ``True``
+            when this function is called from ``StatementBatch``, which already
+            validated the project once.
 
     Returns:
-        PdfResult: Named tuple with all processing results including temp parquet stems,
-            error flags, and lightweight financial summary scalars.  See :data:`PdfResult`
-            for full field descriptions.
+        :class:`~bank_statement_parser.modules.data.PdfResult` with
+        ``result == "SUCCESS"`` when extraction and validation both pass, or
+        ``result == "FAILURE"`` otherwise.  On success ``detail.payload`` is a
+        :class:`~bank_statement_parser.modules.data.Success` instance carrying a
+        :class:`~bank_statement_parser.modules.data.StatementInfo` and a
+        :class:`~bank_statement_parser.modules.data.ParquetFiles`.  On failure
+        ``detail.payload`` is a
+        :class:`~bank_statement_parser.modules.data.Failure` instance with
+        ``error_type`` set to ``"config"``, ``"cab"``, ``"data"``, or
+        ``"other"``.  ``detail.payload.parquet_files`` on a ``Failure`` holds
+        any temporary files that *were* written before the failure, including
+        the ``batch_lines`` file which is always written.
     """
     paths = ProjectPaths.resolve(project_path)
-    batch_lines_stem: str | None = None
-    statement_heads_stem: str | None = None
-    statement_lines_stem: str | None = None
-    cab_stem: str | None = None
-    file_src: str | None = None
-    file_dst: str | None = None
+    batch_lines_path: Path | None = None
+    statement_heads_path: Path | None = None
+    statement_lines_path: Path | None = None
+    cab_path: Path | None = None
     error_cab: bool = False
     error_config: bool = False
     error_data: bool = False
-    # Summary scalars — populated inside the try block before stmt.cleanup().
-    summary_id_statement: str | None = None
-    summary_id_account: str | None = None
-    summary_account: str | None = None
-    summary_statement_date = None
-    summary_payments_in = None
-    summary_payments_out = None
-    summary_opening_balance = None
-    summary_closing_balance = None
+    error_other: bool = False
+    error_message: str = ""
+    error_detail_str: str = ""
+    # StatementInfo is only populated on a clean success path
+    statement_info: StatementInfo | None = None
     line_start = time()
     batch_line: dict = {}
     batch_line["ID_BATCH"] = batch_id
@@ -658,21 +676,23 @@ def process_pdf_statement(
             error_config = True
             batch_line["ERROR_CONFIG"] = True
             batch_line["STD_ERROR_MESSAGE"] += stmt.error_message
+            error_message = stmt.error_message
             print(f"[line {batch_line['STD_BATCH_LINE']}] {pdf.name}: {stmt.error_message}")
-        elif not stmt.success:
-            # Statement parsed but failed checks & balances validation
-            error_cab = True
-            batch_line["ERROR_CAB"] = True
-            detail = _cab_detail(stmt.checks_and_balances)
-            cab_message = f"** Checks & Balances Failure **{detail}"
-            batch_line["STD_ERROR_MESSAGE"] += cab_message
-            print(f"[line {batch_line['STD_BATCH_LINE']}] {pdf.name}: {cab_message}")
         else:
-            # Statement parsed and validated successfully — persist to parquet.
-            # Each parquet class gets its own try/except so that a failure in one
-            # (e.g. a schema mismatch in StatementHeads) does not prevent the other
-            # classes from being written.  A write failure is flagged as error_data
-            # and does not prevent the CAB write below.
+            # Statement parsed — persist all data regardless of CAB outcome.
+            # A CAB failure returns REVIEW (not FAILURE), so statement_heads,
+            # statement_lines, and checks_and_balances are all written here.
+            # If CAB failed, note the error but continue to write everything.
+            if not stmt.success:
+                error_cab = True
+                batch_line["ERROR_CAB"] = True
+                detail_str = _cab_detail(stmt.checks_and_balances)
+                cab_message = f"** Checks & Balances Failure **{detail_str}"
+                batch_line["STD_ERROR_MESSAGE"] += cab_message
+                error_message = cab_message
+                error_detail_str = detail_str
+                print(f"[line {batch_line['STD_BATCH_LINE']}] {pdf.name}: {cab_message}")
+
             try:
                 # Save extracted header data
                 pq_statement_heads = pq.StatementHeads(
@@ -686,7 +706,7 @@ def process_pdf_statement(
                     header_results=stmt.header_results,
                 )
                 pq_statement_heads.create()
-                statement_heads_stem = paths.statement_heads_temp_stem(idx, batch_id)
+                statement_heads_path = paths.statement_heads_temp(idx, batch_id)
                 pq_statement_heads.cleanup()
                 pq_statement_heads = None
             except Exception as e:
@@ -695,6 +715,7 @@ def process_pdf_statement(
                 batch_line["STD_SUCCESS"] = False
                 error_data = True
                 batch_line["ERROR_DATA"] = True
+                error_message += parquet_error
                 print(f"[line {batch_line['STD_BATCH_LINE']}] {pdf.name}: {parquet_error}")
                 traceback.print_exc(file=sys.stderr)
 
@@ -706,7 +727,7 @@ def process_pdf_statement(
                     lines_results=stmt.lines_results,
                 )
                 pq_statement_lines.create()
-                statement_lines_stem = paths.statement_lines_temp_stem(idx, batch_id)
+                statement_lines_path = paths.statement_lines_temp(idx, batch_id)
                 pq_statement_lines.cleanup()
                 pq_statement_lines = None
             except Exception as e:
@@ -715,8 +736,33 @@ def process_pdf_statement(
                 batch_line["STD_SUCCESS"] = False
                 error_data = True
                 batch_line["ERROR_DATA"] = True
+                error_message += parquet_error
                 print(f"[line {batch_line['STD_BATCH_LINE']}] {pdf.name}: {parquet_error}")
                 traceback.print_exc(file=sys.stderr)
+
+            # Build StatementInfo from scalar summary slots populated by Statement.__init__.
+            # Built for both SUCCESS and REVIEW paths; omitted only if a data write failed
+            # or header extraction returned no rows (scalars remain None).
+            if (
+                not error_data
+                and stmt.config
+                and stmt.std_statement_date is not None
+                and stmt.std_payments_in is not None
+                and stmt.std_payments_out is not None
+                and stmt.std_opening_balance is not None
+                and stmt.std_closing_balance is not None
+            ):
+                statement_info = StatementInfo(
+                    id_statement=stmt.ID_STATEMENT,
+                    id_account=stmt.ID_ACCOUNT or "",
+                    account=stmt.account or "",
+                    statement_date=stmt.std_statement_date,
+                    payments_in=stmt.std_payments_in,
+                    payments_out=stmt.std_payments_out,
+                    opening_balance=stmt.std_opening_balance,
+                    closing_balance=stmt.std_closing_balance,
+                    filename_new=stmt.file_renamed or "",
+                )
 
         # Save checks & balances only when the DataFrame is populated — an empty
         # frame means Statement construction failed before the validation step ran,
@@ -725,12 +771,12 @@ def process_pdf_statement(
             try:
                 pq_cab = pq.ChecksAndBalances(
                     file=paths.cab_temp(idx, batch_id),
-                    id_statement=stmt.ID_STATEMENT,
+                    id_batchline=batch_line["ID_BATCHLINE"],
                     id_batch=stmt.ID_BATCH,
                     checks_and_balances=stmt.checks_and_balances,
                 )
                 pq_cab.create()
-                cab_stem = paths.cab_temp_stem(idx, batch_id)
+                cab_path = paths.cab_temp(idx, batch_id)
                 pq_cab.cleanup()
                 pq_cab = None
             except Exception as e:
@@ -739,28 +785,17 @@ def process_pdf_statement(
                 batch_line["STD_SUCCESS"] = False
                 error_data = True
                 batch_line["ERROR_DATA"] = True
+                error_message += cab_error
                 print(f"[line {batch_line['STD_BATCH_LINE']}] {pdf.name}: {cab_error}")
                 traceback.print_exc(file=sys.stderr)
 
-        # Capture source path, rename target, and lightweight summary scalars
-        # before destroying the statement object.
-        file_src = str(stmt.file.absolute())
-        file_dst = stmt.file_renamed  # bare filename string, or None
-        summary_id_statement = stmt.ID_STATEMENT
-        summary_id_account = stmt.ID_ACCOUNT
-        summary_account = stmt.account or None
-        summary_statement_date = stmt.std_statement_date
-        summary_payments_in = stmt.std_payments_in
-        summary_payments_out = stmt.std_payments_out
-        summary_opening_balance = stmt.std_opening_balance
-        summary_closing_balance = stmt.std_closing_balance
         stmt.cleanup()
         stmt = None
     except Exception as e:
         # Last-resort guard — should not be reached under normal operation now that
         # Statement.__init__ is non-raising, but kept to protect against unexpected
         # failures outside the statement constructor (e.g. path resolution errors).
-        error_config = True
+        error_other = True
         batch_line["ERROR_CONFIG"] = True
         error_message = f"** Unexpected Failure **: {e}"
         batch_line["STD_ERROR_MESSAGE"] += error_message
@@ -772,32 +807,68 @@ def process_pdf_statement(
     batch_line["STD_DURATION_SECS"] = line_end - line_start
     batch_line["STD_UPDATETIME"] = datetime.now()
 
-    # Save batch line data
+    # Save batch line data — always written regardless of success/failure
     pq_batch_lines = pq.BatchLines(file=paths.batch_lines_temp(idx, batch_id), batch_lines=[batch_line])
     pq_batch_lines.create()
-    batch_lines_stem = paths.batch_lines_temp_stem(idx, batch_id)
+    batch_lines_path = paths.batch_lines_temp(idx, batch_id)
     pq_batch_lines.cleanup()
     pq_batch_lines = None
 
+    # Build the ParquetFiles record — statement-level files only (SUCCESS / REVIEW paths)
+    parquet_files = ParquetFiles(
+        statement_heads=statement_heads_path,
+        statement_lines=statement_lines_path,
+    )
+
+    # SUCCESS: extraction + CAB both passed, no write errors
+    if not error_config and not error_cab and not error_data and not error_other and statement_info is not None:
+        return PdfResult(
+            result="SUCCESS",
+            outcome="SUCCESS",
+            batch_lines=batch_lines_path,
+            checks_and_balances=cab_path,
+            payload=Success(
+                statement_info=statement_info,
+                parquet_files=parquet_files,
+            ),
+        )
+
+    # REVIEW: CAB failed but extraction + writes succeeded — data needs human sign-off
+    if error_cab and not error_data and statement_info is not None:
+        return PdfResult(
+            result="REVIEW",
+            outcome="REVIEW CAB",
+            batch_lines=batch_lines_path,
+            checks_and_balances=cab_path,
+            payload=Review(
+                statement_info=statement_info,
+                parquet_files=parquet_files,
+                message=error_message or batch_line["STD_ERROR_MESSAGE"] or "Unknown CAB failure",
+                message_detail=error_detail_str,
+            ),
+        )
+
+    # FAILURE: determine the most specific failure type
+    if error_config:
+        outcome: Literal["FAILURE CONFIG", "FAILURE DATA", "FAILURE OTHER"] = "FAILURE CONFIG"
+        error_type: Literal["config", "data", "other"] = "config"
+    elif error_data:
+        outcome = "FAILURE DATA"
+        error_type = "data"
+    else:
+        outcome = "FAILURE OTHER"
+        error_type = "other"
+
     return PdfResult(
-        batch_lines_stem=batch_lines_stem,
-        statement_heads_stem=statement_heads_stem,
-        statement_lines_stem=statement_lines_stem,
-        cab_stem=cab_stem,
-        file_src=file_src,
-        file_dst=file_dst,
-        error_cab=error_cab,
-        error_config=error_config,
-        error_data=error_data,
-        id_statement=summary_id_statement,
-        id_account=summary_id_account,
-        account=summary_account,
-        statement_date=summary_statement_date,
-        payments_in=summary_payments_in,
-        payments_out=summary_payments_out,
-        opening_balance=summary_opening_balance,
-        closing_balance=summary_closing_balance,
-        error_message=batch_line["STD_ERROR_MESSAGE"] or None,
+        result="FAILURE",
+        outcome=outcome,
+        batch_lines=batch_lines_path,
+        checks_and_balances=cab_path,
+        payload=Failure(
+            message=error_message or batch_line["STD_ERROR_MESSAGE"] or "Unknown failure",
+            error_type=error_type,
+            message_detail=error_detail_str,
+        ),
     )
 
 
@@ -808,57 +879,79 @@ def delete_temp_files(
     """
     Delete temporary parquet files created during batch processing.
 
-    Cleans up the temporary parquet files that were created when processing
-    each PDF. Should be called after calling both update_parquet() and
-    update_db() to ensure data has been persisted before deletion.
+    Cleans up the temporary Parquet files that were created when processing
+    each PDF.  Should be called after calling both :func:`update_parquet` and
+    :func:`~bank_statement_parser.modules.database.update_db` to ensure data
+    has been persisted before deletion.
+
+    ``batch_lines`` (always written) and ``checks_and_balances`` (written for
+    SUCCESS and REVIEW) are read directly from :class:`~bank_statement_parser.modules.data.PdfResult`.
+    ``statement_heads`` and ``statement_lines`` are read from
+    :attr:`~bank_statement_parser.modules.data.ParquetFiles` inside
+    :class:`~bank_statement_parser.modules.data.Success` or
+    :class:`~bank_statement_parser.modules.data.Review` payloads.
 
     Args:
-        processed_pdfs: List of :class:`PdfResult` entries as returned by
-            :func:`process_pdf_statement`, or :class:`BaseException` for any
-            entry that raised an unhandled worker error.
-        project_path: Optional project root directory used to resolve stems
-            to full paths.
+        processed_pdfs: List of :class:`~bank_statement_parser.modules.data.PdfResult`
+            entries as returned by :func:`process_pdf_statement`, or
+            :class:`BaseException` for any entry that raised an unhandled worker
+            error.
+        project_path: Unused — retained for API compatibility.  Paths are now
+            stored as full :class:`~pathlib.Path` objects inside each result.
     """
-    paths = ProjectPaths.resolve(project_path)
-    for pdf in processed_pdfs:
-        if isinstance(pdf, BaseException):
-            return None
-        elif isinstance(pdf, PdfResult):
-            for stem in (pdf.batch_lines_stem, pdf.statement_heads_stem, pdf.statement_lines_stem, pdf.cab_stem):
-                if stem is not None:
-                    full_path = paths.parquet / f"{stem}.parquet"
-                    if full_path.exists():
-                        full_path.unlink()
+    for entry in processed_pdfs:
+        if isinstance(entry, BaseException):
+            continue
+        if not isinstance(entry, PdfResult):
+            continue
+        # batch_lines is always present; checks_and_balances may be None
+        top_level_paths = (entry.batch_lines, entry.checks_and_balances)
+        # statement_heads / statement_lines live inside Success or Review payloads
+        pq_files = entry.payload.parquet_files if isinstance(entry.payload, (Success, Review)) else None
+        payload_paths = (pq_files.statement_heads, pq_files.statement_lines) if pq_files is not None else ()
+        for full_path in (*top_level_paths, *payload_paths):
+            if full_path is not None and full_path.exists():
+                full_path.unlink()
 
 
 def copy_statements_to_project(
     processed_pdfs: list[BaseException | PdfResult],
+    pdfs: list[Path],
     project_path: Path | None = None,
 ) -> list[Path]:
     """
     Copy processed statement PDFs into the project ``statements/`` directory.
 
-    Each PDF is copied (not moved) to::
+    Each successfully processed PDF is copied (not moved) to::
 
         <project>/statements/<year>/<id_account>/<filename>
 
-    where *year* is derived from the last eight characters of the target filename
-    stem (``YYYYMMDD``) and *id_account* is everything before the trailing
-    ``_YYYYMMDD`` suffix.
+    where *year* is derived from the last eight characters of the target
+    filename stem (``YYYYMMDD``) and *id_account* is everything before the
+    trailing ``_YYYYMMDD`` suffix.
 
-    If two statements in the same batch resolve to the same destination path the
-    later copy overwrites the earlier one, which is consistent with the
-    ``INSERT OR REPLACE`` semantics used by :func:`update_db` and the merge
-    behaviour of :func:`update_parquet`.
+    Pairing between source PDFs and results is done by index: ``pdfs[i]``
+    is the source file for ``processed_pdfs[i]``.  This avoids the need to
+    store the source path inside the result object.
+
+    If two statements in the same batch resolve to the same destination path
+    the later copy overwrites the earlier one, consistent with the
+    ``INSERT OR REPLACE`` semantics used by
+    :func:`~bank_statement_parser.modules.database.update_db` and the merge
+    behaviour of :func:`~bank_statement_parser.modules.parquet.update_parquet`.
 
     Entries in *processed_pdfs* that are a :class:`BaseException` (a fatal
-    worker error) or that carry no rename target (``file_dst`` is ``None``) are
-    silently skipped.
+    worker error) or that have ``result == "FAILURE"`` (no valid rename target)
+    are silently skipped.
 
     Args:
-        processed_pdfs: List of :class:`PdfResult` entries as returned by
-            :func:`process_pdf_statement`, or :class:`BaseException` for any
-            entry that raised an unhandled worker error.
+        processed_pdfs: List of :class:`~bank_statement_parser.modules.data.PdfResult`
+            entries as returned by :func:`process_pdf_statement`, or
+            :class:`BaseException` for any entry that raised an unhandled worker
+            error.
+        pdfs: The original list of PDF :class:`~pathlib.Path` objects passed to
+            the batch, in the same order.  ``pdfs[i]`` is the source for
+            ``processed_pdfs[i]``.
         project_path: Optional project root directory.  When ``None`` the
             default bundled ``project/`` directory is used.
 
@@ -867,20 +960,25 @@ def copy_statements_to_project(
     """
     paths = ProjectPaths.resolve(project_path)
     copied: list[Path] = []
-    for entry in processed_pdfs:
+    for entry, pdf_path in zip(processed_pdfs, pdfs):
+        if isinstance(entry, BaseException):
+            continue
         if not isinstance(entry, PdfResult):
             continue
-        if entry.file_src is None or entry.file_dst is None:
+        if entry.result != "SUCCESS":
+            continue
+        info = entry.payload.statement_info  # type: ignore[union-attr]
+        if not info.filename_new:
             continue
         # Derive year from the last 8 characters of the stem (YYYYMMDD)
-        stem = Path(entry.file_dst).stem  # e.g. "HSBC_UK_SAV_41462695_20210328"
+        stem = Path(info.filename_new).stem  # e.g. "HSBC_UK_SAV_41462695_20210328"
         year = stem[-8:-4]  # characters 0-3 of the date portion → "2021"
         # id_account is everything before the trailing "_YYYYMMDD"
         id_account = stem[: -(len("_YYYYMMDD"))]  # strip "_" + 8 date chars
         dest_dir = paths.statements_dir(year, id_account)
         dest_dir.mkdir(parents=True, exist_ok=True)
-        dest_path = dest_dir / entry.file_dst
-        Path(entry.file_src).copy(dest_path)
+        dest_path = dest_dir / info.filename_new
+        Path(pdf_path).copy(dest_path)
         copied.append(dest_path)
     return copied
 
@@ -931,6 +1029,7 @@ class StatementBatch:
         "pdf_count",
         "log",
         "errors",
+        "reviews",
         "duration_secs",
         "process_secs",
         "parquet_secs",
@@ -997,6 +1096,7 @@ class StatementBatch:
         self.pdf_count: int = len(self.pdfs)
         self.log: list = []
         self.errors: int = 0
+        self.reviews: int = 0
         self.duration_secs: float = 0.00
         self.process_secs: float = 0.00
         self.parquet_secs: float = 0.00
@@ -1038,8 +1138,10 @@ class StatementBatch:
         for idx, pdf in enumerate(self.pdfs):
             result = self.process_single_pdf(idx, pdf)
             self.processed_pdfs.append(result)
-            if isinstance(result, PdfResult) and (result.error_cab or result.error_config or result.error_data):
+            if isinstance(result, PdfResult) and result.result in "FAILURE":
                 self.errors += 1
+            if isinstance(result, PdfResult) and result.result == "REVIEW":
+                self.reviews += 1
 
     async def process_turbo(self):
         """
@@ -1054,8 +1156,10 @@ class StatementBatch:
         """
         self.processed_pdfs = await self.__process_batch_turbo()
         for result in self.processed_pdfs:
-            if isinstance(result, PdfResult) and (result.error_cab or result.error_config or result.error_data):
+            if isinstance(result, PdfResult) and result.result == "FAILURE":
                 self.errors += 1
+            if isinstance(result, PdfResult) and result.result == "REVIEW":
+                self.reviews += 1
         return True
 
     async def __process_batch_turbo(self):
@@ -1092,7 +1196,6 @@ class StatementBatch:
                 loop.run_in_executor(
                     executor,
                     process_pdf_statement,
-                    idx,
                     pdf,
                     self.ID_BATCH,
                     self.ID_SESSION,
@@ -1100,6 +1203,7 @@ class StatementBatch:
                     self.company_key,
                     self.account_key,
                     self.project_path,
+                    idx,
                     True,  # skip_project_validation
                 )
                 for idx, pdf in enumerate(self.pdfs)
@@ -1126,7 +1230,10 @@ class StatementBatch:
             across process boundaries.
 
         Args:
-            idx: Index position of this PDF in the batch.
+        idx: Index position of this PDF in the batch.  Defaults to ``0``
+            when called directly (i.e. outside a batch).  The batch sets
+            this to the enumeration index so that temporary file names are
+            unique across concurrent workers.
             pdf: Path to the PDF file to process.
 
         Returns:
@@ -1180,6 +1287,7 @@ class StatementBatch:
                 account_key=self.account_key,
                 pdf_count=self.pdf_count,
                 errors=self.errors,
+                reviews=self.reviews,
                 duration_secs=self.duration_secs,
                 process_time=self.process_time,
                 paths=ProjectPaths.resolve(resolved),
@@ -1196,6 +1304,7 @@ class StatementBatch:
                 account_key=self.account_key,
                 pdf_count=self.pdf_count,
                 errors=self.errors,
+                reviews=self.reviews,
                 duration_secs=self.duration_secs,
                 process_time=self.process_time,
                 project_path=resolved,
@@ -1227,6 +1336,7 @@ class StatementBatch:
         """
         return copy_statements_to_project(
             processed_pdfs=self.processed_pdfs,
+            pdfs=self.pdfs,
             project_path=project_path if project_path is not None else self.project_path,
         )
 

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -30,6 +30,7 @@ Run with:
 """
 
 import sqlite3
+from dataclasses import replace
 from datetime import timedelta
 from pathlib import Path
 
@@ -278,10 +279,8 @@ class TestCopyStatements:
             assert id_account == expected_id_account, f"id_account folder {id_account!r} != expected {expected_id_account!r}"
 
     def test_count_matches_successful_pdfs(self, good_project):
-        """Number of copied files equals number of PdfResult entries with file_dst set."""
-        expected = sum(
-            1 for e in good_project.batch.processed_pdfs if isinstance(e, PdfResult) and e.file_src is not None and e.file_dst is not None
-        )
+        """Number of copied files equals number of successfully processed PdfResult entries."""
+        expected = sum(1 for e in good_project.batch.processed_pdfs if isinstance(e, PdfResult) and e.result == "SUCCESS")
         copied = good_project.batch.copy_statements_to_project()
         assert len(copied) == expected, f"Expected {expected} copies, got {len(copied)}"
 
@@ -295,23 +294,30 @@ class TestCopyStatements:
         """BaseException entries in processed_pdfs are silently ignored."""
         sentinel = RuntimeError("synthetic worker crash")
         mixed: list[BaseException | PdfResult] = [sentinel, *good_project.batch.processed_pdfs]
-        copied = copy_statements_to_project(mixed, project_path=good_project.project_path)
+        mixed_pdfs = [good_project.pdfs[0], *good_project.pdfs]  # extra dummy pdf for the sentinel
+        copied = copy_statements_to_project(mixed, pdfs=mixed_pdfs, project_path=good_project.project_path)
         # Must still copy the real entries — no crash, no reduction in count
-        expected = sum(
-            1 for e in good_project.batch.processed_pdfs if isinstance(e, PdfResult) and e.file_src is not None and e.file_dst is not None
-        )
+        expected = sum(1 for e in good_project.batch.processed_pdfs if isinstance(e, PdfResult) and e.result == "SUCCESS")
         assert len(copied) == expected
 
     def test_skips_entries_without_file_dst(self, good_project):
-        """PdfResult entries with file_dst=None are silently skipped."""
-        # Build a list that has one extra entry with no dst
+        """PdfResult entries with filename_new='' are silently skipped."""
+        # Build a list that has one extra entry with no filename_new
         real_entries: list[BaseException | PdfResult] = list(good_project.batch.processed_pdfs)
-        # Create a PdfResult-like entry with file_dst=None by using the first real entry
-        first = next(e for e in real_entries if isinstance(e, PdfResult) and e.file_dst is not None)
-        no_dst = PdfResult(*[None if f == "file_dst" else getattr(first, f) for f in PdfResult._fields])
+        # Create a PdfResult entry with filename_new cleared by using the first successful entry
+        first = next(e for e in real_entries if isinstance(e, PdfResult) and e.result == "SUCCESS")
+        first_info = first.payload.statement_info  # type: ignore[union-attr]
+        no_dst = replace(
+            first,
+            payload=replace(
+                first.payload,  # type: ignore[union-attr]
+                statement_info=replace(first_info, filename_new=""),
+            ),
+        )
         mixed: list[BaseException | PdfResult] = [no_dst, *real_entries]
-        copied = copy_statements_to_project(mixed, project_path=good_project.project_path)
-        expected = sum(1 for e in real_entries if isinstance(e, PdfResult) and e.file_src is not None and e.file_dst is not None)
+        mixed_pdfs = [good_project.pdfs[0], *good_project.pdfs]  # extra dummy pdf for no_dst
+        copied = copy_statements_to_project(mixed, pdfs=mixed_pdfs, project_path=good_project.project_path)
+        expected = sum(1 for e in real_entries if isinstance(e, PdfResult) and e.result == "SUCCESS")
         assert len(copied) == expected
 
 


### PR DESCRIPTION
## Summary

- **REVIEW outcome**: Introduces a `Review` dataclass and a `result='REVIEW'` / `outcome='REVIEW CAB'` path on `PdfResult`. A CAB failure no longer produces a `FAILURE` — `statement_heads`, `statement_lines`, and `checks_and_balances` are all persisted for human review, while only `SUCCESS` statements feed the datamart and the statements copy.

- **STD_REVIEW_COUNT**: New `INTEGER` column added to `batch_heads` across all four locations (SQLite schema, `_MIGRATIONS`, Parquet schema, `build_batch_heads_records`). `StatementBatch` gains a `reviews` counter (mirroring `errors`) incremented for every `REVIEW` result in both the sequential and turbo paths. The datamart rebuild guard is updated to `pdf_count > (errors + reviews)` so an all-REVIEW batch does not trigger a spurious rebuild with no new statement data.

- **debug.py cleanup**: `_cab_detail_rows`, `_diagnose_parquet_schemas`, and `_run_build_diagnostic` removed. CAB data is already persisted via the normal batch pipeline and does not need re-capturing during a debug run.

## Test results

133/133 tests pass. `ruff check .` clean.