### PR TITLE
refactor: flatten statements copy destination to top-level directory

### DIFF
--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -96,12 +96,8 @@ class ProjectPaths:
 
     @property
     def statements(self) -> Path:
-        """Root directory for statement copies organised by year and account."""
+        """Root directory for copied statement PDFs."""
         return self.root / "statements"
-
-    def statements_dir(self, year: str, id_account: str) -> Path:
-        """Directory for statement copies for a given year and account."""
-        return self.statements / year / id_account
 
     @property
     def logs(self) -> Path:

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -924,11 +924,10 @@ def copy_statements_to_project(
 
     Each successfully processed PDF is copied (not moved) to::
 
-        <project>/statements/<year>/<id_account>/<filename>
+        <project>/statements/<filename>
 
-    where *year* is derived from the last eight characters of the target
-    filename stem (``YYYYMMDD``) and *id_account* is everything before the
-    trailing ``_YYYYMMDD`` suffix.
+    All statements are written directly at the top level of the
+    ``statements/`` directory, with no year or account sub-folders.
 
     Pairing between source PDFs and results is done by index: ``pdfs[i]``
     is the source file for ``processed_pdfs[i]``.  This avoids the need to
@@ -970,12 +969,7 @@ def copy_statements_to_project(
         info = entry.payload.statement_info  # type: ignore[union-attr]
         if not info.filename_new:
             continue
-        # Derive year from the last 8 characters of the stem (YYYYMMDD)
-        stem = Path(info.filename_new).stem  # e.g. "HSBC_UK_SAV_41462695_20210328"
-        year = stem[-8:-4]  # characters 0-3 of the date portion → "2021"
-        # id_account is everything before the trailing "_YYYYMMDD"
-        id_account = stem[: -(len("_YYYYMMDD"))]  # strip "_" + 8 date chars
-        dest_dir = paths.statements_dir(year, id_account)
+        dest_dir = paths.statements
         dest_dir.mkdir(parents=True, exist_ok=True)
         dest_path = dest_dir / info.filename_new
         Path(pdf_path).copy(dest_path)
@@ -1318,7 +1312,10 @@ class StatementBatch:
         Delegates to the module-level :func:`copy_statements_to_project` function.
         Each PDF is copied (not moved) to::
 
-            <project>/statements/<year>/<id_account>/<filename>
+            <project>/statements/<filename>
+
+        All statements are written directly at the top level of the
+        ``statements/`` directory, with no year or account sub-folders.
 
         This method must be called after the batch has finished processing.
         It is safe to call even when two statements in the batch resolve to the

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -258,25 +258,16 @@ class TestCopyStatements:
         assert empty == [], f"Zero-byte copied files: {empty}"
 
     def test_directory_structure(self, good_project):
-        """Copied files land under statements/<year>/<id_account>/<filename>."""
+        """Copied files land directly under statements/<filename> (flat layout)."""
         paths = ProjectPaths.resolve(good_project.project_path)
         copied = good_project.batch.copy_statements_to_project()
         for dest in copied:
             # dest must be inside <project>/statements/
             assert dest.is_relative_to(paths.statements), f"{dest} is not under {paths.statements}"
-            # Relative path must have exactly three parts: year/id_account/filename
+            # Relative path must have exactly one part: the filename only (no sub-folders)
             rel = dest.relative_to(paths.statements)
             parts = rel.parts
-            assert len(parts) == 3, f"Expected year/id_account/file, got {parts!r} for {dest}"
-            year, id_account, filename = parts
-            # year must be a 4-digit string
-            assert year.isdigit() and len(year) == 4, f"Unexpected year folder {year!r}"
-            # filename stem must end with _YYYYMMDD matching the year folder
-            stem = Path(filename).stem
-            assert stem[-8:-4] == year, f"Year folder {year!r} does not match date in filename stem {stem!r}"
-            # id_account must be the stem minus the trailing _YYYYMMDD
-            expected_id_account = stem[: -(len("_YYYYMMDD"))]
-            assert id_account == expected_id_account, f"id_account folder {id_account!r} != expected {expected_id_account!r}"
+            assert len(parts) == 1, f"Expected flat statements/<filename>, got {parts!r} for {dest}"
 
     def test_count_matches_successful_pdfs(self, good_project):
         """Number of copied files equals number of successfully processed PdfResult entries."""

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -32,7 +32,6 @@ Run with:
 import sqlite3
 from dataclasses import replace
 from datetime import timedelta
-from pathlib import Path
 
 import polars as pl
 


### PR DESCRIPTION
## Summary

- `copy_statements_to_project()` previously copied PDFs into `<project>/statements/<year>/<id_account>/<filename>`. All files are now written directly to `<project>/statements/<filename>` with no sub-folder hierarchy.
- `ProjectPaths.statements_dir(year, id_account)` removed — it was only used to build the old sub-folder path and is now dead code; `paths.statements` covers the destination directly.
- Docstrings updated on the module-level function, the `StatementBatch` method, and the `statements` property to reflect the flat layout.
- `TestCopyStatements.test_directory_structure` updated to assert a single-part relative path instead of the old three-part `year/id_account/file` structure.

All 133 tests pass.