### PR TITLE
feat: add JSON export and refactor export helpers

### DIFF
--- a/docs/guides/exports.md
+++ b/docs/guides/exports.md
@@ -42,10 +42,14 @@ bsp process --pdfs ~/statements --no-export
 #### `export_csv()`
 
 ```python
-export_csv(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None)
+export_csv(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
 ```
 
 Write report data to CSV files in *folder*.
+
+Each table is written as a separate ``.csv`` file named after its logical
+table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
+``account.csv``, etc. for ``type="full"``).
 
 
 **Args:**
@@ -63,10 +67,15 @@ Write report data to CSV files in *folder*.
 #### `export_excel()`
 
 ```python
-export_excel(path: Path | None = None, type: str = 'simple', project_path: Path | None = None)
+export_excel(path: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
 ```
 
 Write report data to an Excel workbook at *path*.
+
+Each table is written as a separate worksheet.  For ``type="simple"`` a
+single ``transactions_table`` sheet is written; for ``type="full"`` six
+sheets are written (``statement``, ``account``, ``calendar``,
+``transactions``, ``balances``, ``gaps``).
 
 
 **Args:**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,10 +36,10 @@ bsp anonymise PATH [--folder] [--pattern GLOB] [--output OUT_FILE] [--output-dir
 
 ## `bsp process`
 
-Discover PDF bank statements, extract transaction data, persist results to Parquet and/or SQLite, copy source PDFs into the project tree, and export reports as Excel and/or CSV. A project folder is created automatically if it does not exist.
+Discover PDF bank statements, extract transaction data, persist results to Parquet and/or SQLite, copy source PDFs into the project tree, and export reports as Excel, CSV, and/or JSON. A project folder is created automatically if it does not exist.
 
 ```
-bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,both}] [--export-type {full,simple}] [--no-export] [--no-copy]
+bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,json,all}] [--export-type {full,simple}] [--no-export] [--no-copy]
 ```
 
 ### Options
@@ -53,7 +53,7 @@ bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--comp
 | `--company` | auto-detect | Company key for config lookup (default: auto-detect from PDF). |
 | `--account` | auto-detect | Account key for config lookup (default: auto-detect from PDF). |
 | `--data` | `both` | Persistence target for update_data() (default: 'both'). Choices: `parquet`, `database`, `both`. |
-| `--export-format` | `both` | Export file format (default: 'both'). Choices: `excel`, `csv`, `both`. |
+| `--export-format` | `all` | Export file format (default: 'all'). Choices: `excel`, `csv`, `json`, `all`. |
 | `--export-type` | `simple` | Export preset. 'simple' (default) exports a single flat transactions table. 'full' exports separate star-schema tables (accounts, calendar, statements, transactions, balances, gaps) intended for loading into an external database. Choices: `full`, `simple`. |
 | `--no-export` | off | Skip the export step entirely. |
 | `--no-copy` | off | Skip copying source PDFs into the project statements/ directory. |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -273,10 +273,14 @@ Available in `bsp.db`:
 #### `export_csv()`
 
 ```python
-export_csv(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None)
+export_csv(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
 ```
 
 Write report data to CSV files in *folder*.
+
+Each table is written as a separate ``.csv`` file named after its logical
+table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
+``account.csv``, etc. for ``type="full"``).
 
 
 **Args:**
@@ -294,10 +298,15 @@ Write report data to CSV files in *folder*.
 #### `export_excel()`
 
 ```python
-export_excel(path: Path | None = None, type: str = 'simple', project_path: Path | None = None)
+export_excel(path: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
 ```
 
 Write report data to an Excel workbook at *path*.
+
+Each table is written as a separate worksheet.  For ``type="simple"`` a
+single ``transactions_table`` sheet is written; for ``type="full"`` six
+sheets are written (``statement``, ``account``, ``calendar``,
+``transactions``, ``balances``, ``gaps``).
 
 
 **Args:**

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -18,7 +18,9 @@ Quick start
     batch.update_data(datadestination="database")             # database only
     batch.export(filetype="excel")  # writes to project export/excel/
     batch.export(filetype="csv")    # writes to project export/csv/
-    batch.copy_statements_to_project()  # copy PDFs to project/statements/{year}/{account}/
+    batch.export(filetype="json")   # writes to project export/json/
+    batch.export(filetype="all")    # writes Excel, CSV, and JSON
+    batch.copy_statements_to_project()  # copy PDFs to project/statements/
     batch.delete_temp_files()
 
     # Read reports from the DB backend
@@ -34,9 +36,9 @@ DB report backend
 -----------------
 ``bsp.db`` exposes FlatTransaction, FactBalance, DimTime, DimStatement,
 DimAccount, FactTransaction, GapReport plus ``export_csv`` / ``export_excel``
-helpers.  Export functions accept an optional ``folder`` / ``path`` argument;
-when omitted they write to the project's ``export/csv/`` or ``export/excel/``
-sub-directory automatically.
+/ ``export_json`` helpers.  Export functions accept an optional ``folder`` /
+``path`` argument; when omitted they write to the project's ``export/csv/``,
+``export/excel/``, or ``export/json/`` sub-directory automatically.
 
     bsp.db.FlatTransaction(...)
 

--- a/src/bank_statement_parser/cli.py
+++ b/src/bank_statement_parser/cli.py
@@ -197,7 +197,7 @@ def main() -> None:
         description=(
             "Discover PDF bank statements, extract transaction data, persist "
             "results to Parquet and/or SQLite, copy source PDFs into the "
-            "project tree, and export reports as Excel and/or CSV. "
+            "project tree, and export reports as Excel, CSV, and/or JSON. "
             "A project folder is created automatically if it does not exist."
         ),
     )
@@ -246,10 +246,10 @@ def main() -> None:
     )
     proc.add_argument(
         "--export-format",
-        choices=["excel", "csv", "both"],
-        default="both",
+        choices=["excel", "csv", "json", "all"],
+        default="all",
         dest="export_format",
-        help="Export file format (default: 'both').",
+        help="Export file format (default: 'all').",
     )
     proc.add_argument(
         "--export-type",

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -5,6 +5,7 @@ Functions:
     export_csv: Write all report CSVs to a folder (defaults to project export/csv/).
     export_excel: Write all report sheets to a single Excel workbook
         (defaults to project export/excel/transactions.xlsx).
+    export_json: Write all report JSON files to a folder (defaults to project export/json/).
 
 Classes:
     FlatTransaction, FactBalance, DimTime, DimStatement, DimAccount,
@@ -76,13 +77,55 @@ def _read_data_filtered(db_path: Path, table_name: str, batch_table: str, batch_
         return pl.read_database(query, connection=conn, execute_options={"parameters": [batch_id]}, infer_schema_length=None).lazy()
 
 
+# Names of the numeric (float) tables in the full export — used by export_excel
+# to pass float_precision=2.
+_FLOAT_TABLES: frozenset[str] = frozenset({"transactions", "balances"})
+
+
+def _collect_report_frames(
+    type: str,
+    project_path: Path | None,
+) -> list[tuple[str, pl.DataFrame]]:
+    """Collect and return report DataFrames for the given export type.
+
+    Each entry in the returned list is a ``(logical_name, DataFrame)`` pair.
+    The logical name is used by callers to derive file names or worksheet names.
+
+    Args:
+        type: Export preset — ``"simple"`` (flat transactions table only) or
+            ``"full"`` (all six star-schema tables).
+        project_path: Optional project root directory.  Falls back to the
+            bundled default project when ``None``.
+
+    Returns:
+        A list of ``(name, DataFrame)`` tuples in export order.
+    """
+    if type == "full":
+        return [
+            ("statement", DimStatement(project_path).all.collect()),
+            ("account", DimAccount(project_path).all.collect()),
+            ("calendar", DimTime(project_path).all.collect()),
+            ("transactions", FactTransaction(project_path).all.collect()),
+            ("balances", FactBalance(project_path).all.collect()),
+            ("gaps", GapReport(project_path).all.collect()),
+        ]
+    # type == "simple"
+    return [
+        ("transactions_table", FlatTransaction(project_path).all.collect()),
+    ]
+
+
 def export_csv(
     folder: Path | None = None,
     type: str = "simple",
     project_path: Path | None = None,
-):
+) -> None:
     """
     Write report data to CSV files in *folder*.
+
+    Each table is written as a separate ``.csv`` file named after its logical
+    table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
+    ``account.csv``, etc. for ``type="full"``).
 
     Args:
         folder: Directory to write CSV files into.  When ``None`` the project's
@@ -99,28 +142,13 @@ def export_csv(
         paths = ProjectPaths.resolve(project_path)
         paths.ensure_subdir_for_write(paths.csv)
         folder = paths.csv
-    if type == "full":
-        DimStatement(project_path).all.collect().write_csv(
-            file=folder.joinpath("statement.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
-        )
-        DimAccount(project_path).all.collect().write_csv(
-            file=folder.joinpath("account.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
-        )
-        DimTime(project_path).all.collect().write_csv(
-            file=folder.joinpath("calendar.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
-        )
-        FactTransaction(project_path).all.collect().write_csv(
-            file=folder.joinpath("transactions.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
-        )
-        FactBalance(project_path).all.collect().write_csv(
-            file=folder.joinpath("balances.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
-        )
-        GapReport(project_path).all.collect().write_csv(
-            file=folder.joinpath("gaps.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
-        )
-    elif type == "simple":
-        FlatTransaction(project_path).all.collect().write_csv(
-            file=folder.joinpath("transactions_table.csv"), separator=",", include_header=True, quote_style="non_numeric", float_precision=2
+    for name, df in _collect_report_frames(type, project_path):
+        df.write_csv(
+            file=folder / f"{name}.csv",
+            separator=",",
+            include_header=True,
+            quote_style="non_numeric",
+            float_precision=2,
         )
 
 
@@ -128,9 +156,14 @@ def export_excel(
     path: Path | None = None,
     type: str = "simple",
     project_path: Path | None = None,
-):
+) -> None:
     """
     Write report data to an Excel workbook at *path*.
+
+    Each table is written as a separate worksheet.  For ``type="simple"`` a
+    single ``transactions_table`` sheet is written; for ``type="full"`` six
+    sheets are written (``statement``, ``account``, ``calendar``,
+    ``transactions``, ``balances``, ``gaps``).
 
     Args:
         path: Full file path for the output ``.xlsx`` workbook.  When ``None``
@@ -148,59 +181,48 @@ def export_excel(
         paths.ensure_subdir_for_write(paths.excel)
         path = paths.excel / "transactions.xlsx"
     with Workbook(str(path)) as wb:
-        if type == "full":
-            DimStatement(project_path).all.collect().write_excel(
+        for name, df in _collect_report_frames(type, project_path):
+            extra: dict = {"float_precision": 2} if name in _FLOAT_TABLES else {}
+            df.write_excel(
                 workbook=wb,
-                worksheet="statement",
+                worksheet=name,
                 autofit=False,
-                table_name="statement",
+                table_name=name,
                 table_style="Table Style Medium 4",
+                **extra,
             )
-            DimAccount(project_path).all.collect().write_excel(
-                workbook=wb,
-                worksheet="account",
-                autofit=False,
-                table_name="account",
-                table_style="Table Style Medium 4",
-            )
-            DimTime(project_path).all.collect().write_excel(
-                workbook=wb,
-                worksheet="calendar",
-                autofit=False,
-                table_name="calendar",
-                table_style="Table Style Medium 4",
-            )
-            FactTransaction(project_path).all.collect().write_excel(
-                workbook=wb,
-                worksheet="transactions",
-                autofit=False,
-                table_name="transactions",
-                table_style="Table Style Medium 4",
-                float_precision=2,
-            )
-            FactBalance(project_path).all.collect().write_excel(
-                workbook=wb,
-                worksheet="balances",
-                autofit=False,
-                table_name="balances",
-                table_style="Table Style Medium 4",
-                float_precision=2,
-            )
-            GapReport(project_path).all.collect().write_excel(
-                workbook=wb,
-                worksheet="gaps",
-                autofit=False,
-                table_name="gaps",
-                table_style="Table Style Medium 4",
-            )
-        elif type == "simple":
-            FlatTransaction(project_path).all.collect().write_excel(
-                workbook=wb,
-                worksheet="transactions_table",
-                autofit=False,
-                table_name="flat",
-                table_style="Table Style Medium 4",
-            )
+
+
+def export_json(
+    folder: Path | None = None,
+    type: str = "simple",
+    project_path: Path | None = None,
+) -> None:
+    """
+    Write report data to JSON files in *folder*.
+
+    Each table is written as a separate ``.json`` file containing a JSON array
+    of row objects, named after its logical table name (e.g.
+    ``transactions_table.json``, or ``statement.json``, ``account.json``, etc.
+    for ``type="full"``).
+
+    Args:
+        folder: Directory to write JSON files into.  When ``None`` the
+            project's ``export/json/`` directory (resolved via *project_path*)
+            is used and created automatically if absent.
+        type: Export preset — ``"simple"`` (flat transactions table) or
+            ``"full"`` (separate star-schema tables for loading into a
+            database).  Defaults to ``"simple"``.
+        project_path: Optional project root used to resolve the default export
+            folder and data sources.  Falls back to the bundled default project
+            when ``None``.
+    """
+    if folder is None:
+        paths = ProjectPaths.resolve(project_path)
+        paths.ensure_subdir_for_write(paths.json)
+        folder = paths.json
+    for name, df in _collect_report_frames(type, project_path):
+        df.write_json(folder / f"{name}.json")
 
 
 class FlatTransaction:

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -17,6 +17,7 @@ import multiprocessing
 import os
 import sys
 import traceback
+import warnings
 from concurrent.futures import ProcessPoolExecutor
 from copy import deepcopy
 from datetime import datetime
@@ -1352,7 +1353,7 @@ class StatementBatch:
 
     def export(
         self,
-        filetype: Literal["excel", "csv", "both"] = "excel",
+        filetype: Literal["excel", "csv", "json", "all", "both"] = "excel",
         folder: Path | None = None,
         type: str = "simple",
         project_path: Path | None = None,
@@ -1362,18 +1363,24 @@ class StatementBatch:
 
         Delegates to the DB-backed module-level export function based on
         *filetype*.  When neither *folder* nor *project_path* is supplied the
-        function writes to the project's ``export/csv/`` or ``export/excel/``
-        sub-directory, creating it if absent.
+        function writes to the project's ``export/csv/``, ``export/excel/``, or
+        ``export/json/`` sub-directory, creating it if absent.
 
         Args:
             filetype: Output format.  ``"excel"`` writes a single ``.xlsx``
                 workbook; ``"csv"`` writes one CSV file per report table;
-                ``"both"`` writes Excel and CSV in sequence.
+                ``"json"`` writes one JSON file per report table; ``"all"``
+                writes Excel, CSV, and JSON in sequence.
                 Defaults to ``"excel"``.
-            folder: For ``filetype="csv"``: directory to write CSV files into,
-                or the workbook path for ``filetype="excel"``.  When ``None``
-                the default export sub-directory for the resolved project is
-                used.
+
+                .. deprecated::
+                    ``"both"`` is a deprecated alias for ``"all"`` and will be
+                    removed in a future release.  Use ``"all"`` instead.
+            folder: Output path passed through to the underlying export
+                function.  For CSV and JSON this is the directory to write
+                files into; for Excel this is the full workbook path.  When
+                ``None`` the default export sub-directory for the resolved
+                project is used.
             type: Export preset passed through to the underlying function.
                 ``"simple"`` exports the flat transactions table only;
                 ``"full"`` exports separate star-schema tables for loading
@@ -1383,8 +1390,16 @@ class StatementBatch:
                 folder.
         """
         if filetype == "both":
+            warnings.warn(
+                "filetype='both' is deprecated and will be removed in a future release. Use filetype='all' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            filetype = "all"
+        if filetype == "all":
             self.export(filetype="excel", folder=folder, type=type, project_path=project_path)
             self.export(filetype="csv", folder=folder, type=type, project_path=project_path)
+            self.export(filetype="json", folder=folder, type=type, project_path=project_path)
             return
         resolved_project_path = project_path if project_path is not None else self.project_path
 
@@ -1392,8 +1407,10 @@ class StatementBatch:
 
         if filetype == "excel":
             _rd.export_excel(path=folder, type=type, project_path=resolved_project_path)
-        else:
+        elif filetype == "csv":
             _rd.export_csv(folder=folder, type=type, project_path=resolved_project_path)
+        elif filetype == "json":
+            _rd.export_json(folder=folder, type=type, project_path=resolved_project_path)
 
     def debug(self, project_path: Path | None = None) -> int:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,14 +144,14 @@ class TestProcessOptions:
         assert action.default == "both"
 
     def test_export_format_choices(self) -> None:
-        """--export-format must accept excel, csv, both."""
+        """--export-format must accept excel, csv, json, all."""
         action = _find_action("process", "--export-format")
-        assert set(action.choices) == {"excel", "csv", "both"}
+        assert set(action.choices) == {"excel", "csv", "json", "all"}
 
     def test_export_format_default(self) -> None:
-        """--export-format must default to 'both'."""
+        """--export-format must default to 'all'."""
         action = _find_action("process", "--export-format")
-        assert action.default == "both"
+        assert action.default == "all"
 
     def test_export_type_choices(self) -> None:
         """--export-type must accept full, simple."""

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -12,15 +12,16 @@ TestDbReports
     processed good-PDF data.
 
 TestExports
-    Verifies CSV and Excel export functions for the database backend,
-    including full and simple presets and the ``filetype="both"``
-    convenience mode on ``StatementBatch.export()``.
+    Verifies CSV, JSON, and Excel export functions for the database backend,
+    including full and simple presets, content/totals checks for CSV and JSON,
+    the ``filetype="all"`` convenience mode on ``StatementBatch.export()``,
+    and the deprecated ``filetype="both"`` alias.
 
 TestCopyStatements
     Verifies that ``copy_statements_to_project()`` copies PDFs into the
-    correct ``statements/<year>/<id_account>/`` directory structure, that
-    all returned paths exist and are non-empty, that the operation is
-    idempotent, and that error/missing entries are silently skipped.
+    correct ``statements/`` directory, that all returned paths exist and
+    are non-empty, that the operation is idempotent, and that error/missing
+    entries are silently skipped.
 
 TestBadStatements
     Verifies that each PDF in ``tests/pdfs/bad/`` is flagged as an error.
@@ -30,6 +31,7 @@ Run with:
 """
 
 import sqlite3
+import warnings
 from dataclasses import replace
 from datetime import timedelta
 
@@ -157,32 +159,47 @@ class TestDbReports:
 # TestExports
 # ---------------------------------------------------------------------------
 
-# CSV file names produced by ``type="full"`` exports.
-_FULL_CSV_FILES = [
-    "statement.csv",
-    "account.csv",
-    "calendar.csv",
-    "transactions.csv",
-    "balances.csv",
-    "gaps.csv",
+# File names produced by ``type="full"`` exports (stem only, no extension).
+_FULL_EXPORT_STEMS = [
+    "statement",
+    "account",
+    "calendar",
+    "transactions",
+    "balances",
+    "gaps",
 ]
+
+# Mapping from full-export logical name → DB table/view name (for row-count checks).
+_FULL_STEM_TO_DB_TABLE = {
+    "statement": "DimStatement",
+    "account": "DimAccount",
+    "calendar": "DimTime",
+    "transactions": "FactTransaction",
+    "balances": "FactBalance",
+    "gaps": "GapReport",
+}
 
 
 class TestExports:
-    """Verify CSV and Excel exports for both backends and presets."""
+    """Verify CSV, JSON, and Excel exports for the database backend and presets.
+
+    Content checks (row counts, monetary totals) are performed for CSV and JSON
+    ``type="simple"`` and ``type="full"`` exports.  Excel tests are
+    existence-only to avoid OS-dependent or extra-dependency parsing.
+    """
 
     # ------------------------------------------------------------------
-    # DB backend — CSV
+    # DB backend — CSV existence
     # ------------------------------------------------------------------
 
     def test_db_export_csv_full(self, good_project):
         """DB export_csv(type='full') writes all six CSV files."""
         db.export_csv(type="full", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        for name in _FULL_CSV_FILES:
-            f = paths.csv / name
-            assert f.exists(), f"Missing CSV: {name}"
-            assert f.stat().st_size > 0, f"Empty CSV: {name}"
+        for stem in _FULL_EXPORT_STEMS:
+            f = paths.csv / f"{stem}.csv"
+            assert f.exists(), f"Missing CSV: {stem}.csv"
+            assert f.stat().st_size > 0, f"Empty CSV: {stem}.csv"
 
     def test_db_export_csv_simple(self, good_project):
         """DB export_csv(type='simple') writes the flat transactions CSV."""
@@ -193,7 +210,42 @@ class TestExports:
         assert f.stat().st_size > 0, "Empty transactions_table.csv (db/simple)"
 
     # ------------------------------------------------------------------
-    # DB backend — Excel
+    # DB backend — CSV content: simple totals
+    # ------------------------------------------------------------------
+
+    def test_csv_simple_totals(self, good_project):
+        """transactions_table.csv row count and monetary totals match the DB mart."""
+        db.export_csv(type="simple", project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        df = pl.read_csv(paths.csv / "transactions_table.csv", schema_overrides={"account_number": pl.String})
+
+        with sqlite3.connect(str(paths.project_db)) as conn:
+            db_rows = conn.execute("SELECT COUNT(*) FROM FlatTransaction").fetchone()[0]
+            db_value_in = conn.execute("SELECT COALESCE(SUM(value_in), 0) FROM FlatTransaction").fetchone()[0]
+            db_value_out = conn.execute("SELECT COALESCE(SUM(value_out), 0) FROM FlatTransaction").fetchone()[0]
+
+        assert df.height == db_rows, f"CSV row count {df.height} != DB {db_rows}"
+        csv_value_in = df["value_in"].sum() or 0
+        csv_value_out = df["value_out"].sum() or 0
+        assert abs(csv_value_in - db_value_in) <= FLOAT_TOL, f"value_in mismatch: CSV={csv_value_in} DB={db_value_in}"
+        assert abs(csv_value_out - db_value_out) <= FLOAT_TOL, f"value_out mismatch: CSV={csv_value_out} DB={db_value_out}"
+
+    # ------------------------------------------------------------------
+    # DB backend — CSV content: full row counts
+    # ------------------------------------------------------------------
+
+    def test_csv_full_row_counts(self, good_project):
+        """Each full-export CSV file has the same row count as its DB source table."""
+        db.export_csv(type="full", project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        with sqlite3.connect(str(paths.project_db)) as conn:
+            for stem, table in _FULL_STEM_TO_DB_TABLE.items():
+                db_rows = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+                df = pl.read_csv(paths.csv / f"{stem}.csv", infer_schema_length=0)
+                assert df.height == db_rows, f"{stem}.csv: CSV rows={df.height} != DB rows={db_rows}"
+
+    # ------------------------------------------------------------------
+    # DB backend — Excel existence only
     # ------------------------------------------------------------------
 
     def test_db_export_excel_full(self, good_project):
@@ -213,22 +265,101 @@ class TestExports:
         assert f.stat().st_size > 0, "Empty transactions.xlsx (db/simple)"
 
     # ------------------------------------------------------------------
-    # StatementBatch.export() — filetype="both"
+    # DB backend — JSON existence
     # ------------------------------------------------------------------
 
-    def test_batch_export_both(self, good_project):
-        """StatementBatch.export(filetype='both') writes both Excel and CSV."""
-        good_project.batch.export(filetype="both", type="full")
+    def test_db_export_json_full(self, good_project):
+        """DB export_json(type='full') writes all six JSON files."""
+        db.export_json(type="full", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        # Excel file must exist
+        for stem in _FULL_EXPORT_STEMS:
+            f = paths.json / f"{stem}.json"
+            assert f.exists(), f"Missing JSON: {stem}.json"
+            assert f.stat().st_size > 0, f"Empty JSON: {stem}.json"
+
+    def test_db_export_json_simple(self, good_project):
+        """DB export_json(type='simple') writes the flat transactions JSON."""
+        db.export_json(type="simple", project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        f = paths.json / "transactions_table.json"
+        assert f.exists(), "Missing transactions_table.json (db/simple)"
+        assert f.stat().st_size > 0, "Empty transactions_table.json (db/simple)"
+
+    # ------------------------------------------------------------------
+    # DB backend — JSON content: simple totals
+    # ------------------------------------------------------------------
+
+    def test_json_simple_totals(self, good_project):
+        """transactions_table.json row count and monetary totals match the DB mart."""
+        db.export_json(type="simple", project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        df = pl.read_json(paths.json / "transactions_table.json")
+
+        with sqlite3.connect(str(paths.project_db)) as conn:
+            db_rows = conn.execute("SELECT COUNT(*) FROM FlatTransaction").fetchone()[0]
+            db_value_in = conn.execute("SELECT COALESCE(SUM(value_in), 0) FROM FlatTransaction").fetchone()[0]
+            db_value_out = conn.execute("SELECT COALESCE(SUM(value_out), 0) FROM FlatTransaction").fetchone()[0]
+
+        assert df.height == db_rows, f"JSON row count {df.height} != DB {db_rows}"
+        json_value_in = df["value_in"].sum() or 0
+        json_value_out = df["value_out"].sum() or 0
+        assert abs(json_value_in - db_value_in) <= FLOAT_TOL, f"value_in mismatch: JSON={json_value_in} DB={db_value_in}"
+        assert abs(json_value_out - db_value_out) <= FLOAT_TOL, f"value_out mismatch: JSON={json_value_out} DB={db_value_out}"
+
+    # ------------------------------------------------------------------
+    # DB backend — JSON content: full row counts
+    # ------------------------------------------------------------------
+
+    def test_json_full_row_counts(self, good_project):
+        """Each full-export JSON file has the same row count as its DB source table."""
+        db.export_json(type="full", project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        with sqlite3.connect(str(paths.project_db)) as conn:
+            for stem, table in _FULL_STEM_TO_DB_TABLE.items():
+                db_rows = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+                df = pl.read_json(paths.json / f"{stem}.json", infer_schema_length=None)
+                assert df.height == db_rows, f"{stem}.json: JSON rows={df.height} != DB rows={db_rows}"
+
+    # ------------------------------------------------------------------
+    # StatementBatch.export() — filetype="all"
+    # ------------------------------------------------------------------
+
+    def test_batch_export_all(self, good_project):
+        """StatementBatch.export(filetype='all') writes Excel, CSV, and JSON."""
+        good_project.batch.export(filetype="all", type="full")
+        paths = ProjectPaths.resolve(good_project.project_path)
+        # Excel
         xlsx = paths.excel / "transactions.xlsx"
-        assert xlsx.exists(), "Missing transactions.xlsx after filetype='both'"
-        assert xlsx.stat().st_size > 0, "Empty transactions.xlsx after filetype='both'"
-        # CSV files must exist
-        for name in _FULL_CSV_FILES:
-            f = paths.csv / name
-            assert f.exists(), f"Missing CSV after filetype='both': {name}"
-            assert f.stat().st_size > 0, f"Empty CSV after filetype='both': {name}"
+        assert xlsx.exists(), "Missing transactions.xlsx after filetype='all'"
+        assert xlsx.stat().st_size > 0, "Empty transactions.xlsx after filetype='all'"
+        # CSV
+        for stem in _FULL_EXPORT_STEMS:
+            f = paths.csv / f"{stem}.csv"
+            assert f.exists(), f"Missing CSV after filetype='all': {stem}.csv"
+            assert f.stat().st_size > 0, f"Empty CSV after filetype='all': {stem}.csv"
+        # JSON
+        for stem in _FULL_EXPORT_STEMS:
+            f = paths.json / f"{stem}.json"
+            assert f.exists(), f"Missing JSON after filetype='all': {stem}.json"
+            assert f.stat().st_size > 0, f"Empty JSON after filetype='all': {stem}.json"
+
+    # ------------------------------------------------------------------
+    # StatementBatch.export() — filetype="both" deprecated alias
+    # ------------------------------------------------------------------
+
+    def test_batch_export_both_deprecated(self, good_project):
+        """filetype='both' emits a DeprecationWarning and still produces output."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            good_project.batch.export(filetype="both", type="simple")
+        dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(dep_warnings) == 1, "Expected exactly one DeprecationWarning for filetype='both'"
+        assert "filetype='both'" in str(dep_warnings[0].message)
+        # Output should still be written (all three formats, simple preset)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        assert (paths.excel / "transactions.xlsx").exists()
+        assert (paths.csv / "transactions_table.csv").exists()
+        assert (paths.json / "transactions_table.json").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `export_json()` to `reports_db.py`, writing a standard JSON array file per table (simple: `transactions_table.json`; full: one file per star-schema table).
- Introduces a shared `_collect_report_frames(type, project_path)` helper used by all three export functions (`export_csv`, `export_excel`, `export_json`), so adding a new table in future only requires a single change.
- `StatementBatch.export()` gains `filetype="json"` and `filetype="all"` (dispatches Excel + CSV + JSON). `filetype="both"` is kept as a deprecated alias with `DeprecationWarning`.
- CLI `--export-format` choices updated to `excel | csv | json | all`; default changed from `"both"` to `"all"`.
- Docs regenerated via `scripts/generate_docs.py`.

## Tests

- `test_db_export_json_full` / `test_db_export_json_simple` — existence + non-empty checks.
- `test_json_simple_totals` — row count and `SUM(value_in/out)` vs DB `FlatTransaction` view.
- `test_json_full_row_counts` — each of 6 JSON files vs its DB source table row count.
- `test_batch_export_all` — asserts all three formats are written.
- `test_batch_export_both_deprecated` — asserts exactly one `DeprecationWarning` mentioning `filetype='both'`.
- `test_export_format_choices` / `test_export_format_default` in `test_cli.py` updated to match new choices/default.

All 140 tests pass; `ruff check .` clean.