### PR TITLE
feat: add export_reporting_data() for stable reporting CSV feeds

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,7 @@ bsp anonymise PATH [--folder] [--pattern GLOB] [--output OUT_FILE] [--output-dir
 Discover PDF bank statements, extract transaction data, persist results to Parquet and/or SQLite, copy source PDFs into the project tree, and export reports as Excel, CSV, and/or JSON. A project folder is created automatically if it does not exist.
 
 ```
-bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,json,all}] [--export-type {full,simple}] [--no-export] [--no-copy]
+bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,json,all,reporting}] [--export-type {full,simple}] [--no-export] [--no-copy]
 ```
 
 ### Options
@@ -53,7 +53,7 @@ bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--comp
 | `--company` | auto-detect | Company key for config lookup (default: auto-detect from PDF). |
 | `--account` | auto-detect | Account key for config lookup (default: auto-detect from PDF). |
 | `--data` | `both` | Persistence target for update_data() (default: 'both'). Choices: `parquet`, `database`, `both`. |
-| `--export-format` | `all` | Export file format (default: 'all'). Choices: `excel`, `csv`, `json`, `all`. |
+| `--export-format` | `all` | Export file format (default: 'all'). Choices: `excel`, `csv`, `json`, `all`, `reporting`. |
 | `--export-type` | `simple` | Export preset. 'simple' (default) exports a single flat transactions table. 'full' exports separate star-schema tables (accounts, calendar, statements, transactions, balances, gaps) intended for loading into an external database. Choices: `full`, `simple`. |
 | `--no-export` | off | Skip the export step entirely. |
 | `--no-copy` | off | Skip copying source PDFs into the project statements/ directory. |

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -16,10 +16,11 @@ Quick start
     batch.update_data()                                       # writes to parquet + database
     batch.update_data(datadestination="parquet")              # parquet only
     batch.update_data(datadestination="database")             # database only
-    batch.export(filetype="excel")  # writes to project export/excel/
-    batch.export(filetype="csv")    # writes to project export/csv/
-    batch.export(filetype="json")   # writes to project export/json/
-    batch.export(filetype="all")    # writes Excel, CSV, and JSON
+    batch.export(filetype="excel")       # writes to project export/excel/
+    batch.export(filetype="csv")         # writes to project export/csv/
+    batch.export(filetype="json")        # writes to project export/json/
+    batch.export(filetype="all")         # writes Excel, CSV, and JSON
+    batch.export(filetype="reporting")   # writes CSV feeds to reporting/data/simple/ and reporting/data/full/
     batch.copy_statements_to_project()  # copy PDFs to project/statements/
     batch.delete_temp_files()
 
@@ -36,11 +37,13 @@ DB report backend
 -----------------
 ``bsp.db`` exposes FlatTransaction, FactBalance, DimTime, DimStatement,
 DimAccount, FactTransaction, GapReport plus ``export_csv`` / ``export_excel``
-/ ``export_json`` helpers.  Export functions accept an optional ``folder`` /
-``path`` argument; when omitted they write to the project's ``export/csv/``,
-``export/excel/``, or ``export/json/`` sub-directory automatically.
+/ ``export_json`` / ``export_reporting_data`` helpers.  Export functions accept
+an optional ``folder`` / ``path`` argument; when omitted they write to the
+project's ``export/csv/``, ``export/excel/``, ``export/json/``, or
+``reporting/data/simple|full/`` sub-directory automatically.
 
     bsp.db.FlatTransaction(...)
+    bsp.db.export_reporting_data(project_path=Path("/my/project"))  # reporting feeds
 
 Database utilities
 ------------------

--- a/src/bank_statement_parser/cli.py
+++ b/src/bank_statement_parser/cli.py
@@ -246,7 +246,7 @@ def main() -> None:
     )
     proc.add_argument(
         "--export-format",
-        choices=["excel", "csv", "json", "all"],
+        choices=["excel", "csv", "json", "all", "reporting"],
         default="all",
         dest="export_format",
         help="Export file format (default: 'all').",

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -49,6 +49,9 @@ class ProjectPaths:
             project.db
           export/
             csv/  excel/  json/
+          reporting/
+            data/
+              simple/  full/
           log/
             debug/
 
@@ -93,6 +96,26 @@ class ProjectPaths:
     @property
     def json(self) -> Path:
         return self.exports / "json"
+
+    @property
+    def reporting(self) -> Path:
+        """Root reporting directory."""
+        return self.root / "reporting"
+
+    @property
+    def reporting_data(self) -> Path:
+        """Directory containing reporting data feeds (CSV files)."""
+        return self.reporting / "data"
+
+    @property
+    def reporting_data_simple(self) -> Path:
+        """Reporting data directory for the simple (flat transactions) feed."""
+        return self.reporting_data / "simple"
+
+    @property
+    def reporting_data_full(self) -> Path:
+        """Reporting data directory for the full (star-schema) feed."""
+        return self.reporting_data / "full"
 
     @property
     def statements(self) -> Path:
@@ -246,6 +269,8 @@ class ProjectPaths:
             self.csv,
             self.excel,
             self.json,
+            self.reporting_data_simple,
+            self.reporting_data_full,
             self.log_debug,
         ):
             directory.mkdir(parents=True, exist_ok=True)

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -6,6 +6,8 @@ Functions:
     export_excel: Write all report sheets to a single Excel workbook
         (defaults to project export/excel/transactions.xlsx).
     export_json: Write all report JSON files to a folder (defaults to project export/json/).
+    export_reporting_data: Write CSV reporting feeds to reporting/data/simple/ and
+        reporting/data/full/ inside the project directory.
 
 Classes:
     FlatTransaction, FactBalance, DimTime, DimStatement, DimAccount,
@@ -223,6 +225,45 @@ def export_json(
         folder = paths.json
     for name, df in _collect_report_frames(type, project_path):
         df.write_json(folder / f"{name}.json")
+
+
+def export_reporting_data(project_path: Path | None = None) -> None:
+    """
+    Write CSV reporting feeds to the project's ``reporting/data/`` sub-directories.
+
+    Calls :func:`export_csv` twice — once with ``type="simple"`` writing to
+    ``reporting/data/simple/`` and once with ``type="full"`` writing to
+    ``reporting/data/full/``.  Both directories are created automatically if
+    absent.
+
+    This produces a stable set of CSV files that external reporting tools
+    (e.g. Power BI, Tableau, Excel) can point at directly without needing
+    to know about the full export machinery.
+
+    Args:
+        project_path: Optional project root directory.  Falls back to the
+            bundled default project when ``None``.
+
+    Example::
+
+        import bank_statement_parser as bsp
+        from pathlib import Path
+
+        bsp.db.export_reporting_data(project_path=Path("/my/project"))
+        # Writes:
+        #   /my/project/reporting/data/simple/transactions_table.csv
+        #   /my/project/reporting/data/full/statement.csv
+        #   /my/project/reporting/data/full/account.csv
+        #   /my/project/reporting/data/full/calendar.csv
+        #   /my/project/reporting/data/full/transactions.csv
+        #   /my/project/reporting/data/full/balances.csv
+        #   /my/project/reporting/data/full/gaps.csv
+    """
+    paths = ProjectPaths.resolve(project_path)
+    paths.ensure_subdir_for_write(paths.reporting_data_simple)
+    paths.ensure_subdir_for_write(paths.reporting_data_full)
+    export_csv(folder=paths.reporting_data_simple, type="simple", project_path=project_path)
+    export_csv(folder=paths.reporting_data_full, type="full", project_path=project_path)
 
 
 class FlatTransaction:

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -1353,7 +1353,7 @@ class StatementBatch:
 
     def export(
         self,
-        filetype: Literal["excel", "csv", "json", "all", "both"] = "excel",
+        filetype: Literal["excel", "csv", "json", "all", "both", "reporting"] = "excel",
         folder: Path | None = None,
         type: str = "simple",
         project_path: Path | None = None,
@@ -1370,7 +1370,9 @@ class StatementBatch:
             filetype: Output format.  ``"excel"`` writes a single ``.xlsx``
                 workbook; ``"csv"`` writes one CSV file per report table;
                 ``"json"`` writes one JSON file per report table; ``"all"``
-                writes Excel, CSV, and JSON in sequence.
+                writes Excel, CSV, and JSON in sequence; ``"reporting"`` writes
+                CSV feeds to ``reporting/data/simple/`` and
+                ``reporting/data/full/`` inside the project directory.
                 Defaults to ``"excel"``.
 
                 .. deprecated::
@@ -1411,6 +1413,8 @@ class StatementBatch:
             _rd.export_csv(folder=folder, type=type, project_path=resolved_project_path)
         elif filetype == "json":
             _rd.export_json(folder=folder, type=type, project_path=resolved_project_path)
+        elif filetype == "reporting":
+            _rd.export_reporting_data(project_path=resolved_project_path)
 
     def debug(self, project_path: Path | None = None) -> int:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,9 +144,9 @@ class TestProcessOptions:
         assert action.default == "both"
 
     def test_export_format_choices(self) -> None:
-        """--export-format must accept excel, csv, json, all."""
+        """--export-format must accept excel, csv, json, all, reporting."""
         action = _find_action("process", "--export-format")
-        assert set(action.choices) == {"excel", "csv", "json", "all"}
+        assert set(action.choices) == {"excel", "csv", "json", "all", "reporting"}
 
     def test_export_format_default(self) -> None:
         """--export-format must default to 'all'."""

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -361,6 +361,35 @@ class TestExports:
         assert (paths.csv / "transactions_table.csv").exists()
         assert (paths.json / "transactions_table.json").exists()
 
+    # ------------------------------------------------------------------
+    # DB backend — export_reporting_data existence
+    # ------------------------------------------------------------------
+
+    def test_reporting_data_simple_exists(self, good_project):
+        """export_reporting_data() writes transactions_table.csv to reporting/data/simple/."""
+        db.export_reporting_data(project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        f = paths.reporting_data_simple / "transactions_table.csv"
+        assert f.exists(), "Missing reporting/data/simple/transactions_table.csv"
+        assert f.stat().st_size > 0, "Empty reporting/data/simple/transactions_table.csv"
+
+    def test_reporting_data_full_exists(self, good_project):
+        """export_reporting_data() writes all six CSVs to reporting/data/full/."""
+        db.export_reporting_data(project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        for stem in _FULL_EXPORT_STEMS:
+            f = paths.reporting_data_full / f"{stem}.csv"
+            assert f.exists(), f"Missing reporting/data/full/{stem}.csv"
+            assert f.stat().st_size > 0, f"Empty reporting/data/full/{stem}.csv"
+
+    def test_batch_export_reporting(self, good_project):
+        """StatementBatch.export(filetype='reporting') populates both reporting directories."""
+        good_project.batch.export(filetype="reporting")
+        paths = ProjectPaths.resolve(good_project.project_path)
+        assert (paths.reporting_data_simple / "transactions_table.csv").exists()
+        for stem in _FULL_EXPORT_STEMS:
+            assert (paths.reporting_data_full / f"{stem}.csv").exists()
+
 
 # ---------------------------------------------------------------------------
 # TestCopyStatements


### PR DESCRIPTION
## Summary

- Adds `export_reporting_data(project_path)` to `reports_db.py`. Writes the `"simple"` CSV preset to `reporting/data/simple/` and the `"full"` preset to `reporting/data/full/` by delegating to `export_csv()` twice. Both directories are created if absent.
- Adds four new properties to `ProjectPaths`: `reporting`, `reporting_data`, `reporting_data_simple`, `reporting_data_full`. `ensure_dirs()` now eagerly creates `reporting/data/simple/` and `reporting/data/full/` alongside the existing export directories.
- `StatementBatch.export()` gains `filetype="reporting"`, and `cli.py` `--export-format` gains `"reporting"` as a valid choice.
- `__init__.py` quick-start and `bsp.db` docstring updated to document the new function and filetype.

## Tests

- `test_reporting_data_simple_exists` — `export_reporting_data()` writes a non-empty `transactions_table.csv` to `reporting/data/simple/`.
- `test_reporting_data_full_exists` — all six full-preset CSVs are written to `reporting/data/full/`.
- `test_batch_export_reporting` — `StatementBatch.export(filetype="reporting")` populates both directories.
- `test_export_format_choices` updated to include `"reporting"`.

All 143 tests pass; `ruff check .` clean.