### PR TITLE
docs: fix documentation audit gaps

### DIFF
--- a/docs/guides/exports.md
+++ b/docs/guides/exports.md
@@ -3,9 +3,9 @@
 
 # Export Options
 
-bank_statement_parser supports exporting report data in CSV and Excel formats,
-with two export presets and two data backends. Exports are generated automatically
-by `bsp process` or can be triggered manually via the Python API.
+bank_statement_parser supports exporting report data in CSV, Excel, and JSON formats,
+with two export presets and a dedicated reporting feed for external BI tools. Exports are
+generated automatically by `bsp process` or can be triggered manually via the Python API.
 
 ## Export Presets
 
@@ -30,14 +30,14 @@ bsp process --pdfs ~/statements --no-export
 | Option | Choices | Default | Description |
 | --- | --- | --- | --- |
 | `--export-type` | `simple`, `full` | `simple` | Export preset |
-| `--export-format` | `excel`, `csv`, `both` | `both` | Output file format |
+| `--export-format` | `excel`, `csv`, `json`, `all`, `reporting` | `all` | Output file format |
 | `--no-export` | — | off | Skip the export step entirely |
 
 ## Python API
 
 ### Export functions
 
-`bsp.db` provides `export_csv()` and `export_excel()`:
+`bsp.db` provides `export_csv()`, `export_excel()`, `export_json()`, and `export_reporting_data()`:
 
 #### `export_csv()`
 
@@ -90,6 +90,73 @@ sheets are written (``statement``, ``account``, ``calendar``,
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
 
+#### `export_json()`
+
+```python
+export_json(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+```
+
+Write report data to JSON files in *folder*.
+
+Each table is written as a separate ``.json`` file containing a JSON array
+of row objects, named after its logical table name (e.g.
+``transactions_table.json``, or ``statement.json``, ``account.json``, etc.
+for ``type="full"``).
+
+
+**Args:**
+
+- `folder` — Directory to write JSON files into.  When ``None`` the
+  project's ``export/json/`` directory (resolved via *project_path*)
+  is used and created automatically if absent.
+- `type` — Export preset — ``"simple"`` (flat transactions table) or
+  ``"full"`` (separate star-schema tables for loading into a
+  database).  Defaults to ``"simple"``.
+- `project_path` — Optional project root used to resolve the default export
+  folder and data sources.  Falls back to the bundled default project
+  when ``None``.
+
+#### `export_reporting_data()`
+
+```python
+export_reporting_data(project_path: Path | None = None) -> None
+```
+
+Write CSV reporting feeds to the project's ``reporting/data/`` sub-directories.
+
+Calls :func:`export_csv` twice — once with ``type="simple"`` writing to
+``reporting/data/simple/`` and once with ``type="full"`` writing to
+``reporting/data/full/``.  Both directories are created automatically if
+absent.
+
+This produces a stable set of CSV files that external reporting tools
+(e.g. Power BI, Tableau, Excel) can point at directly without needing
+to know about the full export machinery.
+
+
+**Args:**
+
+- `project_path` — Optional project root directory.  Falls back to the
+  bundled default project when ``None``.
+
+
+**Example:**
+
+```python
+    import bank_statement_parser as bsp
+    from pathlib import Path
+
+    bsp.db.export_reporting_data(project_path=Path("/my/project"))
+    # Writes:
+    #   /my/project/reporting/data/simple/transactions_table.csv
+    #   /my/project/reporting/data/full/statement.csv
+    #   /my/project/reporting/data/full/account.csv
+    #   /my/project/reporting/data/full/calendar.csv
+    #   /my/project/reporting/data/full/transactions.csv
+    #   /my/project/reporting/data/full/balances.csv
+    #   /my/project/reporting/data/full/gaps.csv
+```
+
 ### Usage examples
 
 ```python
@@ -100,6 +167,12 @@ bsp.db.export_csv()
 
 # Export full star-schema tables to Excel
 bsp.db.export_excel(type='full')
+
+# Export JSON
+bsp.db.export_json()
+
+# Write stable CSV feeds for BI tools (simple + full presets)
+bsp.db.export_reporting_data()
 
 # Export to a custom directory
 from pathlib import Path
@@ -157,10 +230,19 @@ Gap detection report. Flags periods where the closing balance of one statement d
 | --- | --- | --- |
 | CSV | `export/csv/transactions_table.csv` | Flat transaction table |
 | Excel | `export/excel/transactions.xlsx` | Sheet: `transactions_table` |
+| JSON | `export/json/transactions_table.json` | Flat transaction table (JSON array) |
 
 ### Full preset
 
 | Format | Files / Sheets | Contents |
 | --- | --- | --- |
-| CSV | `statement.csv`, `account.csv`, `calendar.csv`, `transactions.csv`, `balances.csv`, `gaps.csv` | Separate star-schema tables |
-| Excel | `transactions.xlsx` with sheets: `statement`, `account`, `calendar`, `transactions`, `balances`, `gaps` | Star-schema workbook |
+| CSV | `export/csv/` — `statement.csv`, `account.csv`, `calendar.csv`, `transactions.csv`, `balances.csv`, `gaps.csv` | Separate star-schema tables |
+| Excel | `export/excel/transactions.xlsx` with sheets: `statement`, `account`, `calendar`, `transactions`, `balances`, `gaps` | Star-schema workbook |
+| JSON | `export/json/` — `statement.json`, `account.json`, `calendar.json`, `transactions.json`, `balances.json`, `gaps.json` | Separate star-schema tables (JSON arrays) |
+
+### Reporting feed (`--export-format reporting`)
+
+| Preset | Path | Contents |
+| --- | --- | --- |
+| `simple` | `reporting/data/simple/transactions_table.csv` | Flat transaction table |
+| `full` | `reporting/data/full/` — `statement.csv`, `account.csv`, `calendar.csv`, `transactions.csv`, `balances.csv`, `gaps.csv` | Star-schema CSV feeds |

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -24,7 +24,11 @@ a set of bank statements.
     csv/               # CSV report exports
     excel/             # Excel workbook exports
     json/              # JSON exports
-  statements/          # Source PDF copies organised by year/account
+  reporting/
+    data/
+      simple/          # Flat transactions CSV feed
+      full/            # Star-schema CSV feeds
+  statements/          # Source PDF copies (flat, one file per statement)
   log/
     debug/             # Per-statement debug output
 ```
@@ -74,12 +78,15 @@ List of ``Path`` objects for every directory that was created.
 
 - `NotADirectoryError` — If *destination* exists but is a file, not a directory.
 
-Example::
 
-import bank_statement_parser as bsp
-from pathlib import Path
+**Example:**
 
-bsp.copy_project_folders(Path("~/my_project").expanduser())
+```python
+    import bank_statement_parser as bsp
+    from pathlib import Path
+
+    bsp.copy_project_folders(Path("~/my_project").expanduser())
+```
 
 ### `validate_or_initialise_project()`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,7 +36,7 @@ bsp anonymise PATH [--folder] [--pattern GLOB] [--output OUT_FILE] [--output-dir
 
 ## `bsp process`
 
-Discover PDF bank statements, extract transaction data, persist results to Parquet and/or SQLite, copy source PDFs into the project tree, and export reports as Excel, CSV, and/or JSON. A project folder is created automatically if it does not exist.
+Discover PDF bank statements, extract transaction data, persist results to Parquet and/or SQLite, copy source PDFs into the project tree, and export reports as Excel, CSV, JSON, and/or CSV reporting feeds. A project folder is created automatically if it does not exist.
 
 ```
 bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,json,all,reporting}] [--export-type {full,simple}] [--no-export] [--no-copy]

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -209,9 +209,13 @@ Empty and rebuild all mart tables (DimTime, DimAccount, DimStatement, FactTransa
 
 *function* — `bank_statement_parser.data`
 
+Create (or recreate) the raw SQLite database with all tables and indexes.
+
 ### `bsp.Housekeeping`
 
 *class* — `bank_statement_parser.data`
+
+Orphan-detection and cascaded-delete helper for the raw SQLite database.
 
 ## PDF anonymisation
 
@@ -250,6 +254,8 @@ Raised when bsp's own pytest suite fails during TestHarness.setup().
 flat = bsp.db.FlatTransaction().all.collect()
 bsp.db.export_csv()
 bsp.db.export_excel()
+bsp.db.export_json()
+bsp.db.export_reporting_data()
 ```
 
 ### Report classes
@@ -320,3 +326,70 @@ sheets are written (``statement``, ``account``, ``calendar``,
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+
+#### `export_json()`
+
+```python
+export_json(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+```
+
+Write report data to JSON files in *folder*.
+
+Each table is written as a separate ``.json`` file containing a JSON array
+of row objects, named after its logical table name (e.g.
+``transactions_table.json``, or ``statement.json``, ``account.json``, etc.
+for ``type="full"``).
+
+
+**Args:**
+
+- `folder` — Directory to write JSON files into.  When ``None`` the
+  project's ``export/json/`` directory (resolved via *project_path*)
+  is used and created automatically if absent.
+- `type` — Export preset — ``"simple"`` (flat transactions table) or
+  ``"full"`` (separate star-schema tables for loading into a
+  database).  Defaults to ``"simple"``.
+- `project_path` — Optional project root used to resolve the default export
+  folder and data sources.  Falls back to the bundled default project
+  when ``None``.
+
+#### `export_reporting_data()`
+
+```python
+export_reporting_data(project_path: Path | None = None) -> None
+```
+
+Write CSV reporting feeds to the project's ``reporting/data/`` sub-directories.
+
+Calls :func:`export_csv` twice — once with ``type="simple"`` writing to
+``reporting/data/simple/`` and once with ``type="full"`` writing to
+``reporting/data/full/``.  Both directories are created automatically if
+absent.
+
+This produces a stable set of CSV files that external reporting tools
+(e.g. Power BI, Tableau, Excel) can point at directly without needing
+to know about the full export machinery.
+
+
+**Args:**
+
+- `project_path` — Optional project root directory.  Falls back to the
+  bundled default project when ``None``.
+
+
+**Example:**
+
+```python
+    import bank_statement_parser as bsp
+    from pathlib import Path
+
+    bsp.db.export_reporting_data(project_path=Path("/my/project"))
+    # Writes:
+    #   /my/project/reporting/data/simple/transactions_table.csv
+    #   /my/project/reporting/data/full/statement.csv
+    #   /my/project/reporting/data/full/account.csv
+    #   /my/project/reporting/data/full/calendar.csv
+    #   /my/project/reporting/data/full/transactions.csv
+    #   /my/project/reporting/data/full/balances.csv
+    #   /my/project/reporting/data/full/gaps.csv
+```

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -621,8 +621,8 @@ def _docstring_to_markdown(docstring: str) -> str:
     for line in lines:
         stripped = line.strip()
 
-        # Detect Google-style section headers
-        section_match = re.match(r"^(Args|Returns|Raises|Example|Note|Warning)s?:\s*$", stripped)
+        # Detect Google-style section headers (also handles RST-style "Example::")
+        section_match = re.match(r"^(Args|Returns|Raises|Example|Note|Warning)s?::?\s*$", stripped)
         if section_match:
             section_name = section_match.group(1)
             if section_name == "Example":
@@ -1396,6 +1396,8 @@ def generate_python_api() -> str:
     w("flat = bsp.db.FlatTransaction().all.collect()")
     w("bsp.db.export_csv()")
     w("bsp.db.export_excel()")
+    w("bsp.db.export_json()")
+    w("bsp.db.export_reporting_data()")
     w("```")
     w()
 
@@ -1443,7 +1445,7 @@ def generate_python_api() -> str:
     w("Available in `bsp.db`:")
     w()
 
-    export_funcs = _extract_function_docs(db_source, ["export_csv", "export_excel"])
+    export_funcs = _extract_function_docs(db_source, ["export_csv", "export_excel", "export_json", "export_reporting_data"])
     for func in export_funcs:
         w(f"#### `{func.name}()`")
         w()
@@ -1653,7 +1655,11 @@ def generate_project_structure() -> str:
     w("    csv/               # CSV report exports")
     w("    excel/             # Excel workbook exports")
     w("    json/              # JSON exports")
-    w("  statements/          # Source PDF copies organised by year/account")
+    w("  reporting/")
+    w("    data/")
+    w("      simple/          # Flat transactions CSV feed")
+    w("      full/            # Star-schema CSV feeds")
+    w("  statements/          # Source PDF copies (flat, one file per statement)")
     w("  log/")
     w("    debug/             # Per-statement debug output")
     w("```")
@@ -1766,7 +1772,7 @@ def generate_exports_guide() -> str:
     """Generate the Export Options guide from report module docstrings."""
     db_source = _REPORTS_DB_PY.read_text(encoding="utf-8")
 
-    db_funcs = _extract_function_docs(db_source, ["export_csv", "export_excel"])
+    db_funcs = _extract_function_docs(db_source, ["export_csv", "export_excel", "export_json", "export_reporting_data"])
 
     report_classes = [
         "FlatTransaction",
@@ -1788,9 +1794,9 @@ def generate_exports_guide() -> str:
     w()
     w("# Export Options")
     w()
-    w("bank_statement_parser supports exporting report data in CSV and Excel formats,")
-    w("with two export presets and two data backends. Exports are generated automatically")
-    w("by `bsp process` or can be triggered manually via the Python API.")
+    w("bank_statement_parser supports exporting report data in CSV, Excel, and JSON formats,")
+    w("with two export presets and a dedicated reporting feed for external BI tools. Exports are")
+    w("generated automatically by `bsp process` or can be triggered manually via the Python API.")
     w()
     w("## Export Presets")
     w()
@@ -1817,7 +1823,7 @@ def generate_exports_guide() -> str:
     w("| Option | Choices | Default | Description |")
     w("| --- | --- | --- | --- |")
     w("| `--export-type` | `simple`, `full` | `simple` | Export preset |")
-    w("| `--export-format` | `excel`, `csv`, `both` | `both` | Output file format |")
+    w("| `--export-format` | `excel`, `csv`, `json`, `all`, `reporting` | `all` | Output file format |")
     w("| `--no-export` | — | off | Skip the export step entirely |")
     w()
 
@@ -1825,11 +1831,11 @@ def generate_exports_guide() -> str:
     w()
     w("### Export functions")
     w()
-    w("`bsp.db` provides `export_csv()` and `export_excel()`:")
+    w("`bsp.db` provides `export_csv()`, `export_excel()`, `export_json()`, and `export_reporting_data()`:")
     w()
 
     for func in db_funcs:
-        w(f"#### `export_{func.name.split('_')[-1]}()`")
+        w(f"#### `{func.name}()`")
         w()
         w("```python")
         w(func.signature)
@@ -1850,6 +1856,12 @@ def generate_exports_guide() -> str:
     w("# Export full star-schema tables to Excel")
     w("bsp.db.export_excel(type='full')")
     w()
+    w("# Export JSON")
+    w("bsp.db.export_json()")
+    w("")
+    w("# Write stable CSV feeds for BI tools (simple + full presets)")
+    w("bsp.db.export_reporting_data()")
+    w("")
     w("# Export to a custom directory")
     w("from pathlib import Path")
     w("bsp.db.export_csv(folder=Path('~/exports'))")
@@ -1898,16 +1910,29 @@ def generate_exports_guide() -> str:
     w("| --- | --- | --- |")
     w("| CSV | `export/csv/transactions_table.csv` | Flat transaction table |")
     w("| Excel | `export/excel/transactions.xlsx` | Sheet: `transactions_table` |")
+    w("| JSON | `export/json/transactions_table.json` | Flat transaction table (JSON array) |")
     w()
     w("### Full preset")
     w()
     w("| Format | Files / Sheets | Contents |")
     w("| --- | --- | --- |")
     w(
-        "| CSV | `statement.csv`, `account.csv`, `calendar.csv`, `transactions.csv`, `balances.csv`, `gaps.csv` | Separate star-schema tables |"
+        "| CSV | `export/csv/` — `statement.csv`, `account.csv`, `calendar.csv`, `transactions.csv`, `balances.csv`, `gaps.csv` | Separate star-schema tables |"
     )
     w(
-        "| Excel | `transactions.xlsx` with sheets: `statement`, `account`, `calendar`, `transactions`, `balances`, `gaps` | Star-schema workbook |"
+        "| Excel | `export/excel/transactions.xlsx` with sheets: `statement`, `account`, `calendar`, `transactions`, `balances`, `gaps` | Star-schema workbook |"
+    )
+    w(
+        "| JSON | `export/json/` — `statement.json`, `account.json`, `calendar.json`, `transactions.json`, `balances.json`, `gaps.json` | Separate star-schema tables (JSON arrays) |"
+    )
+    w()
+    w("### Reporting feed (`--export-format reporting`)")
+    w()
+    w("| Preset | Path | Contents |")
+    w("| --- | --- | --- |")
+    w("| `simple` | `reporting/data/simple/transactions_table.csv` | Flat transaction table |")
+    w(
+        "| `full` | `reporting/data/full/` — `statement.csv`, `account.csv`, `calendar.csv`, `transactions.csv`, `balances.csv`, `gaps.csv` | Star-schema CSV feeds |"
     )
 
     return "\n".join(doc)

--- a/src/bank_statement_parser/cli.py
+++ b/src/bank_statement_parser/cli.py
@@ -197,7 +197,8 @@ def main() -> None:
         description=(
             "Discover PDF bank statements, extract transaction data, persist "
             "results to Parquet and/or SQLite, copy source PDFs into the "
-            "project tree, and export reports as Excel, CSV, and/or JSON. "
+            "project tree, and export reports as Excel, CSV, JSON, and/or "
+            "CSV reporting feeds. "
             "A project folder is created automatically if it does not exist."
         ),
     )

--- a/src/bank_statement_parser/data/create_project_db.py
+++ b/src/bank_statement_parser/data/create_project_db.py
@@ -129,7 +129,20 @@ def create_table(conn, table_name, schema: dict, with_fk: bool = False):
     conn.execute(create_sql)
 
 
-def main(db_path: Path, with_fk: bool = False):
+def main(db_path: Path, with_fk: bool = False) -> None:
+    """Create (or recreate) the raw SQLite database with all tables and indexes.
+
+    Drops any existing database file at *db_path* and creates a fresh one with
+    all raw source tables (``batch_heads``, ``batch_lines``, ``statement_heads``,
+    ``statement_lines``, ``checks_and_balances``) plus their indexes and views.
+
+    Args:
+        db_path: Filesystem path for the SQLite database file.  If the file
+            already exists it is deleted before the new database is created.
+        with_fk: When ``True`` the tables are created with ``FOREIGN KEY``
+            constraints (useful for strict-integrity environments).  Defaults
+            to ``False``.
+    """
     if db_path.exists():
         db_path.unlink()
 

--- a/src/bank_statement_parser/data/housekeeping.py
+++ b/src/bank_statement_parser/data/housekeeping.py
@@ -4,6 +4,16 @@ from pathlib import Path
 
 
 class Housekeeping:
+    """Orphan-detection and cascaded-delete helper for the raw SQLite database.
+
+    Inspects foreign-key relationships between the raw source tables and
+    identifies rows whose parent key no longer exists.  Can report orphans or
+    delete them in dependency order.
+
+    Args:
+        db_path: Path to the project's ``database/project.db`` SQLite file.
+    """
+
     FK_RELATIONSHIPS = [
         ("checks_and_balances", "ID_BATCHLINE", "batch_lines", "ID_BATCHLINE"),
         ("checks_and_balances", "ID_BATCH", "batch_heads", "ID_BATCH"),


### PR DESCRIPTION
## Summary

- **`bsp.create_db()` and `bsp.Housekeeping` missing docstrings** — added Google-style docstrings to `create_project_db.py::main()` and `housekeeping.py::Housekeeping`; the generator now picks them up via re-export following
- **`Example::` RST blocks rendered as plain text** — fixed `_docstring_to_markdown()` regex to accept both `Example:` and `Example::` so `export_reporting_data()` example renders as a fenced code block in `exports.md` and `python-api.md`
- **Output Files table missing JSON and reporting entries** — `generate_exports_guide()` now documents JSON files for simple/full presets and adds a new Reporting feed section
- **`statements/` description stale** — updated directory tree comment from "organised by year/account" to "flat, one file per statement" (matches PR #48 flatten)
- **CLI `bsp process` description** — updated `cli.py` description to mention CSV reporting feeds alongside Excel/CSV/JSON
- **Regenerated all 6 docs pages** after all generator fixes

All 143 tests pass. `ruff check .` clean.