### PR TITLE
feat: TOML-driven export spec engine with QuickBooks UK formats

### DIFF
--- a/src/bank_statement_parser/dev.py
+++ b/src/bank_statement_parser/dev.py
@@ -1,14 +1,17 @@
 from pathlib import Path
 
+# from bank_statement_parser import get_exchange_rates
+
 # import bank_statement_parser as bsp
 from bank_statement_parser.modules import statements
 
 
 def main():
-
+    project_path = Path("/home/boscorat/Downloads/2024/bsp_project")
     # bsp.anonymise_pdf(Path("/home/boscorat/Projects/tsb_spend_and_save_example_1.pdf"))
     # laptop
-    folder = Path("/Users/boscorat/Library/CloudStorage/OneDrive-Personal/OpenStan/Statements/HSBC/2024")
+    # folder = Path("/Users/boscorat/Library/CloudStorage/OneDrive-Personal/OpenStan/Statements/HSBC/2024")
+    folder = Path("/home/boscorat/Downloads/2025")
     # folder = Path("/home/boscorat/repos/bank_statement_parser/tests/pdfs/bad")
     include_subdirs = True  # set True to also include one level of subdirectories
 
@@ -25,14 +28,16 @@ def main():
     batch = statements.StatementBatch(
         pdfs=pdfs,
         turbo=True,
-        project_path=Path("/Users/boscorat/Projects/bsp_project"),
+        # project_path=Path("/Users/boscorat/Projects/bsp_project"),
+        project_path=Path(project_path),
     )
     print(f"total: {batch.duration_secs}, process: {batch.process_secs}, parquet: {batch.parquet_secs}, db: {batch.db_secs}")
     # batch.debug()
 
     batch.update_data()
-    batch.copy_statements_to_project()
-    batch.delete_temp_files()
+    # get_exchange_rates(project_path=project_path)
+    # batch.copy_statements_to_project()
+    # batch.delete_temp_files()
     batch.export(filetype="all")  # writes Excel, CSV, and JSON
     batch.export(filetype="reporting")  # writes Excel, CSV, and JSON
     # print(f"total: {batch.duration_secs}, process: {batch.process_secs}, parquet: {batch.parquet_secs}, db: {batch.db_secs}")

--- a/src/bank_statement_parser/modules/export_spec.py
+++ b/src/bank_statement_parser/modules/export_spec.py
@@ -1,0 +1,634 @@
+"""
+Export spec engine — load TOML spec files and produce filtered, formatted exports.
+
+A spec file declares the source table, column mapping, date/number formatting,
+string sanitisation, and output options (format, split mode, polarity).  The
+:func:`export_spec` function is the single public entry point.
+
+Functions:
+    export_spec: Load a TOML spec and write filtered, formatted export file(s).
+
+Private helpers:
+    _load_spec: Parse and validate a TOML spec file into an :class:`ExportSpec`.
+    _build_frame: Query the database and apply account/date/statement filters.
+    _apply_column_mapping: Rename, compute, and select output columns.
+    _apply_date_format: Format date columns as strings per the spec.
+    _sanitise_strings: Silently strip forbidden characters from string columns.
+    _write_frames: Write one or more DataFrames to CSV or XLSX.
+"""
+
+import re
+import sqlite3
+import tomllib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+from xlsxwriter import Workbook
+
+from bank_statement_parser.modules.errors import ConfigError, ProjectDatabaseMissing
+from bank_statement_parser.modules.paths import ProjectPaths
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Supported computed column tokens
+_COMPUTED_SIGNED_AMOUNT = "computed:signed_amount"
+
+# All recognised computed tokens — used for validation
+_KNOWN_COMPUTED: frozenset[str] = frozenset({_COMPUTED_SIGNED_AMOUNT})
+
+# Columns in FlatTransaction that contain dates (need format conversion)
+_DATE_COLUMNS: frozenset[str] = frozenset({"transaction_date", "statement_date"})
+
+# Allowed source tables / views
+_ALLOWED_TABLES: frozenset[str] = frozenset(
+    {
+        "FlatTransaction",
+        "FactTransaction",
+        "FactBalance",
+        "DimStatement",
+        "DimAccount",
+        "DimTime",
+        "GapReport",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# ExportSpec dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ExportSpec:
+    """Immutable representation of an export spec loaded from a TOML file.
+
+    Attributes:
+        description: Human-readable description of the spec.
+        source_table: DB table or view to query (e.g. ``"FlatTransaction"``).
+        format: Output format — ``"csv"`` or ``"xlsx"``.
+        split_by_statement: When ``True``, produce one file per ``id_statement``.
+        columns: Ordered mapping of export column name → source column name or
+            computed token (e.g. ``"computed:signed_amount"``).
+        date_format: :func:`strftime` format string for date columns
+            (e.g. ``"%d/%m/%Y"``).
+        float_precision: Decimal places for numeric output columns.
+        invert_polarity: When ``True``, negate all computed monetary values.
+        blank_zeros: When ``True``, replace ``0.0`` with ``null`` in numeric
+            output columns before writing.
+        strip_chars: Characters silently removed from every string field.
+    """
+
+    description: str
+    source_table: str
+    format: str
+    split_by_statement: bool
+    columns: dict[str, str]
+    date_format: str
+    float_precision: int
+    invert_polarity: bool
+    blank_zeros: bool
+    strip_chars: str
+
+
+# ---------------------------------------------------------------------------
+# _load_spec
+# ---------------------------------------------------------------------------
+
+
+def _load_spec(spec_path: Path) -> ExportSpec:
+    """Parse and validate a TOML spec file, returning an :class:`ExportSpec`.
+
+    Args:
+        spec_path: Path to the ``.toml`` spec file.
+
+    Returns:
+        A validated :class:`ExportSpec` instance.
+
+    Raises:
+        ConfigError: If the file cannot be read, is missing required keys,
+            or contains invalid values.
+    """
+    if not spec_path.exists():
+        raise ConfigError(f"Export spec file not found: {spec_path}")
+
+    try:
+        with open(spec_path, "rb") as fh:
+            raw = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigError(f"Export spec is not valid TOML ({spec_path}): {exc}") from exc
+
+    # ---- required sections ----
+    for section in ("meta", "export", "columns", "format", "sanitise"):
+        if section not in raw:
+            raise ConfigError(f"Export spec missing required section [{section}]: {spec_path}")
+
+    meta = raw["meta"]
+    export = raw["export"]
+    columns = raw["columns"]
+    fmt = raw["format"]
+    sanitise = raw["sanitise"]
+
+    # ---- [meta] ----
+    description: str = _require_str(meta, "description", spec_path)
+    source_table: str = _require_str(meta, "source_table", spec_path)
+    if source_table not in _ALLOWED_TABLES:
+        raise ConfigError(
+            f"Export spec source_table {source_table!r} is not a recognised table/view (allowed: {sorted(_ALLOWED_TABLES)}): {spec_path}"
+        )
+
+    # ---- [export] ----
+    fmt_value: str = _require_str(export, "format", spec_path)
+    if fmt_value not in ("csv", "xlsx"):
+        raise ConfigError(f"Export spec format must be 'csv' or 'xlsx', got {fmt_value!r}: {spec_path}")
+    split_by_statement: bool = _require_bool(export, "split_by_statement", spec_path)
+
+    # ---- [columns] ----
+    if not isinstance(columns, dict) or not columns:
+        raise ConfigError(f"Export spec [columns] must be a non-empty table: {spec_path}")
+    for col_name, source in columns.items():
+        if not isinstance(source, str):
+            raise ConfigError(f"Export spec [columns] value for {col_name!r} must be a string: {spec_path}")
+        if source.startswith("computed:") and source not in _KNOWN_COMPUTED:
+            raise ConfigError(
+                f"Export spec unknown computed token {source!r} for column {col_name!r} (known: {sorted(_KNOWN_COMPUTED)}): {spec_path}"
+            )
+
+    # ---- [format] ----
+    date_format: str = _require_str(fmt, "date_format", spec_path)
+    float_precision: int = _require_int(fmt, "float_precision", spec_path)
+    invert_polarity: bool = _require_bool(fmt, "invert_polarity", spec_path)
+    blank_zeros: bool = _require_bool(fmt, "blank_zeros", spec_path)
+
+    # ---- [sanitise] ----
+    strip_chars: str = _require_str(sanitise, "strip_chars", spec_path)
+
+    return ExportSpec(
+        description=description,
+        source_table=source_table,
+        format=fmt_value,
+        split_by_statement=split_by_statement,
+        columns=dict(columns),
+        date_format=date_format,
+        float_precision=float_precision,
+        invert_polarity=invert_polarity,
+        blank_zeros=blank_zeros,
+        strip_chars=strip_chars,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _load_spec helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_str(section: dict, key: str, spec_path: Path) -> str:
+    """Return a string value from *section[key]*, raising ConfigError if absent or wrong type."""
+    if key not in section:
+        raise ConfigError(f"Export spec missing required key {key!r}: {spec_path}")
+    value = section[key]
+    if not isinstance(value, str):
+        raise ConfigError(f"Export spec key {key!r} must be a string, got {type(value).__name__!r}: {spec_path}")
+    return value
+
+
+def _require_bool(section: dict, key: str, spec_path: Path) -> bool:
+    """Return a bool value from *section[key]*, raising ConfigError if absent or wrong type."""
+    if key not in section:
+        raise ConfigError(f"Export spec missing required key {key!r}: {spec_path}")
+    value = section[key]
+    if not isinstance(value, bool):
+        raise ConfigError(f"Export spec key {key!r} must be a boolean, got {type(value).__name__!r}: {spec_path}")
+    return value
+
+
+def _require_int(section: dict, key: str, spec_path: Path) -> int:
+    """Return an int value from *section[key]*, raising ConfigError if absent or wrong type."""
+    if key not in section:
+        raise ConfigError(f"Export spec missing required key {key!r}: {spec_path}")
+    value = section[key]
+    # bool is a subclass of int in Python — reject it explicitly
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ConfigError(f"Export spec key {key!r} must be an integer, got {type(value).__name__!r}: {spec_path}")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# _build_frame
+# ---------------------------------------------------------------------------
+
+# Columns needed beyond those declared in a spec when split_by_statement is True.
+# We always fetch id_statement so we can partition, then drop it from output.
+_SPLIT_ANCHOR = "id_statement"
+
+
+def _build_frame(
+    db_path: Path,
+    spec: ExportSpec,
+    account_key: str,
+    date_from: date | None,
+    date_to: date | None,
+    statement_key: str | None,
+) -> pl.LazyFrame:
+    """Query the database, apply filters, and return a raw :class:`pl.LazyFrame`.
+
+    Filters are applied as parameterised SQL (no user-value interpolation).
+    The returned frame contains all columns from *source_table* plus, when
+    ``split_by_statement`` is ``True`` and the source is ``FlatTransaction``,
+    an ``id_statement`` column joined from ``FactTransaction``.
+
+    Args:
+        db_path: Path to the SQLite project database.
+        spec: The loaded :class:`ExportSpec`.
+        account_key: Value to match against ``DimAccount.id_account``.
+        date_from: Optional earliest transaction date (inclusive).
+        date_to: Optional latest transaction date (inclusive).
+        statement_key: Optional ``id_statement`` value to restrict rows.
+
+    Returns:
+        A :class:`pl.LazyFrame` of the filtered rows.
+    """
+    params: list = [account_key]
+    where_clauses: list[str] = []
+
+    # FlatTransaction is a view over FactTransaction + DimStatement + DimAccount.
+    # Re-implement the same joins against the base tables so we can filter on
+    # da.id_account without re-joining through the view (which would risk fan-out
+    # if transaction_number is non-unique across accounts).
+    if spec.source_table == "FlatTransaction":
+        id_statement_col = ", ft2.id_statement" if spec.split_by_statement else ""
+        base_query = (
+            f"SELECT ft2.id_date AS transaction_date, ds.statement_date, ds.filename,"
+            f" da.company, da.account_type, da.account_number, da.sortcode, da.account_holder,"
+            f" ft2.transaction_number, ft2.transaction_credit_or_debit AS CD,"
+            f" ft2.transaction_type AS type, ft2.transaction_desc,"
+            f" SUBSTR(ft2.transaction_desc, 1, 25) AS short_desc,"
+            f" ft2.value_in, ft2.value_out, ft2.value{id_statement_col}"
+            f" FROM FactTransaction ft2"
+            f" INNER JOIN DimStatement ds ON ft2.statement_id = ds.statement_id"
+            f" INNER JOIN DimAccount da ON ft2.account_id = da.account_id"
+        )
+        where_clauses.append("da.id_account = ?")
+    else:
+        # For other tables that already carry id_account directly
+        base_query = f"SELECT * FROM {spec.source_table}"  # noqa: S608
+        where_clauses.append("id_account = ?")
+
+    if date_from is not None:
+        where_clauses.append("transaction_date >= ?")
+        params.append(date_from.isoformat())
+    if date_to is not None:
+        where_clauses.append("transaction_date <= ?")
+        params.append(date_to.isoformat())
+    if statement_key is not None:
+        if spec.source_table == "FlatTransaction":
+            where_clauses.append("ft2.id_statement = ?")
+        else:
+            where_clauses.append("id_statement = ?")
+        params.append(statement_key)
+
+    query = base_query
+    if where_clauses:
+        query = f"{base_query} WHERE {' AND '.join(where_clauses)}"
+
+    with sqlite3.connect(db_path) as conn:
+        return pl.read_database(
+            query,
+            connection=conn,
+            execute_options={"parameters": params},
+            infer_schema_length=None,
+        ).lazy()
+
+
+# ---------------------------------------------------------------------------
+# _apply_column_mapping
+# ---------------------------------------------------------------------------
+
+
+def _apply_column_mapping(df: pl.LazyFrame, spec: ExportSpec) -> pl.LazyFrame:
+    """Rename columns, compute derived values, and select only output columns.
+
+    Handles the ``computed:signed_amount`` token: produces ``value_in -
+    value_out``, optionally negated when ``spec.invert_polarity`` is ``True``.
+
+    Args:
+        df: Input :class:`pl.LazyFrame` from the database query.
+        spec: The loaded :class:`ExportSpec`.
+
+    Returns:
+        A :class:`pl.LazyFrame` containing only the mapped output columns,
+        in the order declared in the spec.
+    """
+    expressions: list[pl.Expr] = []
+
+    for export_name, source in spec.columns.items():
+        if source == _COMPUTED_SIGNED_AMOUNT:
+            amount_expr = pl.col("value_in") - pl.col("value_out")
+            if spec.invert_polarity:
+                amount_expr = -amount_expr
+            expressions.append(amount_expr.alias(export_name))
+        else:
+            expressions.append(pl.col(source).alias(export_name))
+
+    return df.select(expressions)
+
+
+# ---------------------------------------------------------------------------
+# _apply_date_format
+# ---------------------------------------------------------------------------
+
+
+def _apply_date_format(df: pl.LazyFrame, spec: ExportSpec) -> pl.LazyFrame:
+    """Cast and format date columns as strings using ``spec.date_format``.
+
+    Any output column whose *source* in the spec maps to a known date column
+    (``transaction_date``, ``statement_date``) is cast to :class:`pl.Date`
+    and then formatted as a string.
+
+    Args:
+        df: :class:`pl.LazyFrame` after column mapping has been applied.
+        spec: The loaded :class:`ExportSpec`.
+
+    Returns:
+        The :class:`pl.LazyFrame` with date columns replaced by formatted strings.
+    """
+    # Identify output columns whose source was a date field
+    date_output_cols: list[str] = [export_name for export_name, source in spec.columns.items() if source in _DATE_COLUMNS]
+    if not date_output_cols:
+        return df
+    return df.with_columns([pl.col(col).cast(pl.Date).dt.strftime(spec.date_format).alias(col) for col in date_output_cols])
+
+
+# ---------------------------------------------------------------------------
+# _apply_blank_zeros
+# ---------------------------------------------------------------------------
+
+
+def _apply_blank_zeros(df: pl.LazyFrame, spec: ExportSpec) -> pl.LazyFrame:
+    """Replace ``0.0`` with ``null`` in numeric output columns when ``spec.blank_zeros`` is set.
+
+    Only columns with a numeric Polars dtype (Int* or Float*) are modified;
+    string and date columns are left untouched.
+
+    Args:
+        df: :class:`pl.LazyFrame` after column mapping and date formatting.
+        spec: The loaded :class:`ExportSpec`.
+
+    Returns:
+        The :class:`pl.LazyFrame` with zero values replaced by ``null`` in
+        numeric columns.
+    """
+    if not spec.blank_zeros:
+        return df
+    # Inspect the actual schema so we only touch numeric-typed columns.
+    # collect_schema() is a lazy, zero-cost schema inspection.
+    schema = df.collect_schema()
+    _numeric_types = (
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+        pl.Float32,
+        pl.Float64,
+    )
+    exprs: list[pl.Expr] = []
+    for col_name, dtype in schema.items():
+        if isinstance(dtype, _numeric_types):
+            exprs.append(pl.when(pl.col(col_name) == 0).then(None).otherwise(pl.col(col_name)).alias(col_name))
+    if not exprs:
+        return df
+    return df.with_columns(exprs)
+
+
+# ---------------------------------------------------------------------------
+# _sanitise_strings
+# ---------------------------------------------------------------------------
+
+
+def _sanitise_strings(df: pl.LazyFrame, spec: ExportSpec) -> pl.LazyFrame:
+    """Silently strip forbidden characters from all string columns.
+
+    The characters in ``spec.strip_chars`` are compiled into a single regex
+    character class and replaced with empty strings.
+
+    Args:
+        df: :class:`pl.LazyFrame` after all transformations.
+        spec: The loaded :class:`ExportSpec`.
+
+    Returns:
+        The :class:`pl.LazyFrame` with special characters removed from string
+        columns.
+    """
+    if not spec.strip_chars:
+        return df
+    # Build a regex character class from the raw strip_chars string.
+    # re.escape each character individually so regex metacharacters are safe.
+    escaped = "".join(re.escape(c) for c in spec.strip_chars)
+    pattern = f"[{escaped}]"
+
+    # Identify string-typed output columns (sources that are not numeric/date)
+    # We do this by checking known non-string sources.
+    _numeric_sources: frozenset[str] = frozenset(
+        {
+            "value_in",
+            "value_out",
+            "value",
+            "opening_balance",
+            "closing_balance",
+            "movement",
+            _COMPUTED_SIGNED_AMOUNT,
+        }
+    )
+    _date_sources: frozenset[str] = _DATE_COLUMNS
+
+    string_cols: list[str] = [
+        export_name
+        for export_name, source in spec.columns.items()
+        if source not in _numeric_sources and source not in _date_sources and not source.startswith("computed:")
+    ]
+    if not string_cols:
+        return df
+    return df.with_columns([pl.col(col).cast(pl.String).str.replace_all(pattern, "").alias(col) for col in string_cols])
+
+
+# ---------------------------------------------------------------------------
+# _write_frames
+# ---------------------------------------------------------------------------
+
+
+def _write_frames(
+    frames: list[tuple[str, pl.DataFrame]],
+    output_dir: Path,
+    spec: ExportSpec,
+) -> list[Path]:
+    """Write a list of ``(filename_stem, DataFrame)`` pairs to *output_dir*.
+
+    Args:
+        frames: List of ``(stem, DataFrame)`` pairs to write.
+        output_dir: Directory to write output files into.
+        spec: The loaded :class:`ExportSpec` (used for format and precision).
+
+    Returns:
+        List of :class:`Path` objects for every file written.
+    """
+    written: list[Path] = []
+
+    if spec.format == "xlsx":
+        for stem, df in frames:
+            out_path = output_dir / f"{stem}.xlsx"
+            with Workbook(str(out_path)) as wb:
+                df.write_excel(
+                    workbook=wb,
+                    worksheet=stem[:31],  # Excel worksheet name limit
+                    autofit=False,
+                    table_name=re.sub(r"[^A-Za-z0-9_]", "_", stem),
+                    table_style="Table Style Medium 4",
+                    float_precision=spec.float_precision,
+                )
+            written.append(out_path)
+    else:
+        for stem, df in frames:
+            out_path = output_dir / f"{stem}.csv"
+            df.write_csv(
+                file=out_path,
+                separator=",",
+                include_header=True,
+                quote_style="non_numeric",
+                float_precision=spec.float_precision,
+                null_value="",
+            )
+            written.append(out_path)
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# export_spec — public entry point
+# ---------------------------------------------------------------------------
+
+
+def export_spec(
+    spec: Path,
+    *,
+    account_key: str,
+    project_path: Path | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    statement_key: str | None = None,
+    split_by_statement: bool | None = None,
+    format: str | None = None,
+    invert_polarity: bool | None = None,
+) -> list[Path]:
+    """Load a TOML export spec and write filtered, formatted export file(s).
+
+    The spec file declares the source table, column mapping, date/number
+    formatting, string sanitisation, and default output options.  Runtime
+    arguments override the corresponding spec defaults when provided.
+
+    Output is written to ``export/<spec_stem>/`` inside the project directory,
+    created automatically if absent.  Files are named ``<account_key>.csv``
+    (or ``.xlsx``) for single-file exports, or
+    ``<account_key>_<id_statement>.csv`` when splitting by statement.
+
+    Args:
+        spec: Path to the ``.toml`` export spec file.
+        account_key: ``DimAccount.id_account`` value to filter transactions by.
+        project_path: Optional project root directory.  Falls back to the
+            bundled default project when ``None``.
+        date_from: Optional earliest transaction date (inclusive).
+        date_to: Optional latest transaction date (inclusive).
+        statement_key: Optional ``id_statement`` value; restricts output to a
+            single statement's transactions.
+        split_by_statement: Override the spec's ``split_by_statement`` flag.
+            When ``True``, one file is produced per ``id_statement``.
+        format: Override the spec's output format — ``"csv"`` or ``"xlsx"``.
+        invert_polarity: Override the spec's ``invert_polarity`` flag.  When
+            ``True``, the sign of all computed monetary values is negated.
+
+    Returns:
+        A list of :class:`Path` objects for every file written.
+
+    Raises:
+        ConfigError: If the spec file is missing, malformed, or contains
+            invalid values.
+        ProjectDatabaseMissing: If ``database/project.db`` does not exist.
+    """
+    loaded = _load_spec(spec)
+
+    # Apply runtime overrides — rebuild with replaced fields via a plain dict
+    # (ExportSpec is frozen, so we cannot mutate in place).
+    overrides: dict = {}
+    if split_by_statement is not None:
+        overrides["split_by_statement"] = split_by_statement
+    if format is not None:
+        if format not in ("csv", "xlsx"):
+            raise ConfigError(f"export_spec format override must be 'csv' or 'xlsx', got {format!r}")
+        overrides["format"] = format
+    if invert_polarity is not None:
+        overrides["invert_polarity"] = invert_polarity
+
+    if overrides:
+        loaded = ExportSpec(
+            description=loaded.description,
+            source_table=loaded.source_table,
+            format=overrides.get("format", loaded.format),
+            split_by_statement=overrides.get("split_by_statement", loaded.split_by_statement),
+            columns=loaded.columns,
+            date_format=loaded.date_format,
+            float_precision=loaded.float_precision,
+            invert_polarity=overrides.get("invert_polarity", loaded.invert_polarity),
+            blank_zeros=loaded.blank_zeros,
+            strip_chars=loaded.strip_chars,
+        )
+
+    paths = ProjectPaths.resolve(project_path)
+    if not paths.project_db.exists():
+        raise ProjectDatabaseMissing(paths.project_db)
+
+    # Query and transform
+    lf = _build_frame(paths.project_db, loaded, account_key, date_from, date_to, statement_key)
+    lf = _apply_column_mapping(lf, loaded)
+    lf = _apply_date_format(lf, loaded)
+    lf = _apply_blank_zeros(lf, loaded)
+    lf = _sanitise_strings(lf, loaded)
+
+    output_dir = paths.export_specs_output(spec.stem)
+    paths.ensure_subdir_for_write(output_dir)
+
+    if not loaded.split_by_statement:
+        df = lf.collect()
+        stem = account_key
+        written = _write_frames([(stem, df)], output_dir, loaded)
+    else:
+        # Partition by id_statement — the column was added by _build_frame and
+        # removed by _apply_column_mapping (it is not in spec.columns).
+        # We need to re-fetch with split anchor before mapping strips it.
+        lf_raw = _build_frame(paths.project_db, loaded, account_key, date_from, date_to, statement_key)
+        df_raw = lf_raw.collect()
+
+        # Determine unique statement keys
+        if _SPLIT_ANCHOR not in df_raw.columns:
+            # Fallback: write as single file if split column unavailable
+            df_mapped = lf.collect()
+            written = _write_frames([(account_key, df_mapped)], output_dir, loaded)
+        else:
+            statement_ids = df_raw[_SPLIT_ANCHOR].unique().sort().to_list()
+            frames: list[tuple[str, pl.DataFrame]] = []
+            for sid in statement_ids:
+                partition = df_raw.filter(pl.col(_SPLIT_ANCHOR) == sid).lazy()
+                partition = _apply_column_mapping(partition, loaded)
+                partition = _apply_date_format(partition, loaded)
+                partition = _apply_blank_zeros(partition, loaded)
+                partition = _sanitise_strings(partition, loaded)
+                stem = f"{account_key}_{sid}"
+                frames.append((stem, partition.collect()))
+            written = _write_frames(frames, output_dir, loaded)
+
+    return written

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -98,6 +98,23 @@ class ProjectPaths:
         return self.exports / "json"
 
     @property
+    def export_specs(self) -> Path:
+        """Directory containing export spec TOML files."""
+        return self.exports / "specs"
+
+    def export_specs_output(self, spec_stem: str) -> Path:
+        """Output directory for a named export spec (``export/<spec_stem>/``).
+
+        Args:
+            spec_stem: The stem of the spec TOML file (filename without extension),
+                e.g. ``"quickbooks_3column"``.
+
+        Returns:
+            A :class:`Path` pointing to ``export/<spec_stem>/`` inside the project.
+        """
+        return self.exports / spec_stem
+
+    @property
     def reporting(self) -> Path:
         """Root reporting directory."""
         return self.root / "reporting"
@@ -269,6 +286,7 @@ class ProjectPaths:
             self.csv,
             self.excel,
             self.json,
+            self.export_specs,
             self.reporting_data_simple,
             self.reporting_data_full,
             self.log_debug,

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -22,7 +22,6 @@ import polars as pl
 from xlsxwriter import Workbook
 
 from bank_statement_parser.modules.errors import ProjectDatabaseMissing
-from bank_statement_parser.modules.export_spec import export_spec
 from bank_statement_parser.modules.paths import ProjectPaths
 
 

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -8,6 +8,7 @@ Functions:
     export_json: Write all report JSON files to a folder (defaults to project export/json/).
     export_reporting_data: Write CSV reporting feeds to reporting/data/simple/ and
         reporting/data/full/ inside the project directory.
+    export_spec: Load a TOML export spec and write filtered, formatted export file(s).
 
 Classes:
     FlatTransaction, FactBalance, DimTime, DimStatement, DimAccount,
@@ -21,6 +22,7 @@ import polars as pl
 from xlsxwriter import Workbook
 
 from bank_statement_parser.modules.errors import ProjectDatabaseMissing
+from bank_statement_parser.modules.export_spec import export_spec
 from bank_statement_parser.modules.paths import ProjectPaths
 
 
@@ -81,7 +83,7 @@ def _read_data_filtered(db_path: Path, table_name: str, batch_table: str, batch_
 
 # Names of the numeric (float) tables in the full export — used by export_excel
 # to pass float_precision=2.
-_FLOAT_TABLES: frozenset[str] = frozenset({"transactions", "balances"})
+_FLOAT_TABLES: frozenset[str] = frozenset({"transaction_measures", "daily_account_balances"})
 
 
 def _collect_report_frames(
@@ -104,16 +106,16 @@ def _collect_report_frames(
     """
     if type == "full":
         return [
-            ("statement", DimStatement(project_path).all.collect()),
-            ("account", DimAccount(project_path).all.collect()),
-            ("calendar", DimTime(project_path).all.collect()),
-            ("transactions", FactTransaction(project_path).all.collect()),
-            ("balances", FactBalance(project_path).all.collect()),
-            ("gaps", GapReport(project_path).all.collect()),
+            ("statement_dimension", DimStatement(project_path).all.collect()),
+            ("account_dimension", DimAccount(project_path).all.collect()),
+            ("calendar_dimension", DimTime(project_path).all.collect()),
+            ("transaction_measures", FactTransaction(project_path).all.collect()),
+            ("daily_account_balances", FactBalance(project_path).all.collect()),
+            ("missing_statement_report", GapReport(project_path).all.collect()),
         ]
     # type == "simple"
     return [
-        ("transactions_table", FlatTransaction(project_path).all.collect()),
+        ("transactions", FlatTransaction(project_path).all.collect()),
     ]
 
 

--- a/src/bank_statement_parser/project/export/specs/quickbooks_3column.toml
+++ b/src/bank_statement_parser/project/export/specs/quickbooks_3column.toml
@@ -1,0 +1,44 @@
+# QuickBooks Online UK — 3-column bank upload format
+#
+# Accepted by QuickBooks Online (UK) when uploading bank transactions manually.
+# Uses a signed Amount column: positive = money in, negative = money out.
+#
+# Reference:
+#   https://quickbooks.intuit.com/learn-support/en-uk/help-article/bank-transactions/
+#   format-csv-files-excel-get-bank-transactions/L4BjLWckq_GB_en_GB
+#
+# Runtime parameters (passed to export_spec()):
+#   account_key        — required, matches DimAccount.id_account
+#   date_from          — optional date filter (inclusive)
+#   date_to            — optional date filter (inclusive)
+#   statement_key      — optional, restrict to a single statement
+#   split_by_statement — override spec default (false)
+#   invert_polarity    — override spec default (false); set true for credit cards
+#                        whose payments are stored as negative debits
+
+[meta]
+description   = "QuickBooks Online UK — 3-column bank upload format"
+source_table  = "FlatTransaction"
+
+[export]
+format             = "csv"
+split_by_statement = false
+
+# Column mapping: export column name = source column (or computed token)
+# Computed tokens:
+#   computed:signed_amount  — value_in minus value_out (negated if invert_polarity = true)
+[columns]
+Date        = "transaction_date"
+Description = "transaction_desc"
+Amount      = "computed:signed_amount"
+
+[format]
+date_format      = "%d/%m/%Y"
+float_precision  = 2
+invert_polarity  = false
+blank_zeros      = false
+
+[sanitise]
+# Characters stripped silently from all string fields before export.
+# QuickBooks rejects uploads containing these special characters.
+strip_chars = "!@#$%^&*(),.?\":{}|<>"

--- a/src/bank_statement_parser/project/export/specs/quickbooks_4column.toml
+++ b/src/bank_statement_parser/project/export/specs/quickbooks_4column.toml
@@ -1,0 +1,47 @@
+# QuickBooks Online UK — 4-column bank upload format
+#
+# Accepted by QuickBooks Online (UK) when uploading bank transactions manually.
+# Uses separate Credit and Debit columns; the unused column must be left blank
+# for each row (blank_zeros = true enforces this).
+#
+# Reference:
+#   https://quickbooks.intuit.com/learn-support/en-uk/help-article/bank-transactions/
+#   format-csv-files-excel-get-bank-transactions/L4BjLWckq_GB_en_GB
+#
+# Runtime parameters (passed to export_spec()):
+#   account_key        — required, matches DimAccount.id_account
+#   date_from          — optional date filter (inclusive)
+#   date_to            — optional date filter (inclusive)
+#   statement_key      — optional, restrict to a single statement
+#   split_by_statement — override spec default (false)
+#   invert_polarity    — not applicable to this format (Credit/Debit are always
+#                        positive); leave as false
+
+[meta]
+description   = "QuickBooks Online UK — 4-column bank upload format"
+source_table  = "FlatTransaction"
+
+[export]
+format             = "csv"
+split_by_statement = false
+
+# Column mapping: export column name = source column (or computed token)
+# Credit = money in (value_in); Debit = money out (value_out).
+# blank_zeros = true ensures the unused column is blank rather than 0.00,
+# which is required by the QuickBooks import validator.
+[columns]
+Date        = "transaction_date"
+Description = "transaction_desc"
+Credit      = "value_in"
+Debit       = "value_out"
+
+[format]
+date_format      = "%d/%m/%Y"
+float_precision  = 2
+invert_polarity  = false
+blank_zeros      = true
+
+[sanitise]
+# Characters stripped silently from all string fields before export.
+# QuickBooks rejects uploads containing these special characters.
+strip_chars = "!@#$%^&*(),.?\":{}|<>"

--- a/tests/test_export_spec.py
+++ b/tests/test_export_spec.py
@@ -1,0 +1,578 @@
+"""
+test_export_spec.py — integration tests for the export spec engine.
+
+Tests are grouped into four classes:
+
+TestLoadSpec
+    Verifies that _load_spec() correctly parses both shipped QuickBooks spec
+    files, and raises ConfigError for malformed or invalid specs.
+
+TestExportSpecOutput
+    Verifies that export_spec() produces correctly named output files in the
+    right directory, with the expected columns and row counts.
+
+TestExportSpecContent
+    Verifies the data content: date format, numeric precision, blank-zero
+    behaviour, signed-amount polarity, polarity inversion, and string
+    sanitisation.
+
+TestExportSpecFiltering
+    Verifies date-range filtering, statement_key filtering, and
+    split_by_statement partitioning.
+
+Run with:
+    pytest tests/test_export_spec.py -v
+"""
+
+import re
+import sqlite3
+import tempfile
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from bank_statement_parser.modules.errors import ConfigError
+from bank_statement_parser.modules.export_spec import ExportSpec, _load_spec, export_spec
+from bank_statement_parser.modules.paths import ProjectPaths
+
+# ---------------------------------------------------------------------------
+# Helpers / constants
+# ---------------------------------------------------------------------------
+
+# Paths to the two shipped QuickBooks spec files
+_SPECS_DIR = Path(__file__).parent.parent / "src" / "bank_statement_parser" / "project" / "export" / "specs"
+_SPEC_3COL = _SPECS_DIR / "quickbooks_3column.toml"
+_SPEC_4COL = _SPECS_DIR / "quickbooks_4column.toml"
+
+# One well-known id_account present in the good_project test data
+_ACCOUNT_KEY = "HSBC_UK_CUR_12345678"
+
+# Date pattern for dd/mm/yyyy
+_DATE_RE = re.compile(r"^\d{2}/\d{2}/\d{4}$")
+
+
+def _get_flat_transaction_count(project_path: Path, account_key: str) -> int:
+    """Return the number of FlatTransaction rows for a given account.
+
+    Queries FactTransaction directly (joined to DimAccount) to match the
+    production query in _build_frame, which avoids double-join fan-out.
+    """
+    paths = ProjectPaths.resolve(project_path)
+    with sqlite3.connect(paths.project_db) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM FactTransaction ft INNER JOIN DimAccount da ON ft.account_id = da.account_id WHERE da.id_account = ?",
+            [account_key],
+        ).fetchone()
+    return row[0] if row else 0
+
+
+def _get_fact_transaction_value_in_sum(project_path: Path, account_key: str) -> float:
+    """Return SUM(value_in) from FactTransaction for a given account."""
+    paths = ProjectPaths.resolve(project_path)
+    with sqlite3.connect(paths.project_db) as conn:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(ft.value_in), 0)"
+            " FROM FactTransaction ft"
+            " INNER JOIN DimAccount da ON ft.account_id = da.account_id"
+            " WHERE da.id_account = ?",
+            [account_key],
+        ).fetchone()
+    return float(row[0]) if row else 0.0
+
+
+def _get_fact_transaction_value_out_sum(project_path: Path, account_key: str) -> float:
+    """Return SUM(value_out) from FactTransaction for a given account."""
+    paths = ProjectPaths.resolve(project_path)
+    with sqlite3.connect(paths.project_db) as conn:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(ft.value_out), 0)"
+            " FROM FactTransaction ft"
+            " INNER JOIN DimAccount da ON ft.account_id = da.account_id"
+            " WHERE da.id_account = ?",
+            [account_key],
+        ).fetchone()
+    return float(row[0]) if row else 0.0
+
+
+def _get_statement_ids(project_path: Path, account_key: str) -> list[str]:
+    """Return all id_statement values for a given account, sorted."""
+    paths = ProjectPaths.resolve(project_path)
+    with sqlite3.connect(paths.project_db) as conn:
+        rows = conn.execute(
+            "SELECT ds.id_statement"
+            " FROM DimStatement ds"
+            " INNER JOIN DimAccount da ON ds.account_id = da.account_id"
+            " WHERE da.id_account = ?"
+            " ORDER BY ds.id_statement",
+            [account_key],
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# TestLoadSpec
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSpec:
+    """Verify _load_spec() against the shipped TOML files and error cases."""
+
+    def test_load_3column_returns_export_spec(self):
+        """_load_spec() returns an ExportSpec for the 3-column file."""
+        spec = _load_spec(_SPEC_3COL)
+        assert isinstance(spec, ExportSpec)
+
+    def test_load_4column_returns_export_spec(self):
+        """_load_spec() returns an ExportSpec for the 4-column file."""
+        spec = _load_spec(_SPEC_4COL)
+        assert isinstance(spec, ExportSpec)
+
+    def test_3column_columns(self):
+        """3-column spec declares exactly Date, Description, Amount."""
+        spec = _load_spec(_SPEC_3COL)
+        assert list(spec.columns.keys()) == ["Date", "Description", "Amount"]
+
+    def test_4column_columns(self):
+        """4-column spec declares exactly Date, Description, Credit, Debit."""
+        spec = _load_spec(_SPEC_4COL)
+        assert list(spec.columns.keys()) == ["Date", "Description", "Credit", "Debit"]
+
+    def test_3column_signed_amount_computed(self):
+        """3-column spec Amount maps to computed:signed_amount."""
+        spec = _load_spec(_SPEC_3COL)
+        assert spec.columns["Amount"] == "computed:signed_amount"
+
+    def test_4column_credit_debit_sources(self):
+        """4-column spec Credit → value_in, Debit → value_out."""
+        spec = _load_spec(_SPEC_4COL)
+        assert spec.columns["Credit"] == "value_in"
+        assert spec.columns["Debit"] == "value_out"
+
+    def test_3column_format_csv(self):
+        """3-column spec format is 'csv'."""
+        spec = _load_spec(_SPEC_3COL)
+        assert spec.format == "csv"
+
+    def test_4column_blank_zeros_true(self):
+        """4-column spec has blank_zeros = true."""
+        spec = _load_spec(_SPEC_4COL)
+        assert spec.blank_zeros is True
+
+    def test_3column_blank_zeros_false(self):
+        """3-column spec has blank_zeros = false."""
+        spec = _load_spec(_SPEC_3COL)
+        assert spec.blank_zeros is False
+
+    def test_date_format_is_uk(self):
+        """Both specs use the UK date format %%d/%%m/%%Y."""
+        assert _load_spec(_SPEC_3COL).date_format == "%d/%m/%Y"
+        assert _load_spec(_SPEC_4COL).date_format == "%d/%m/%Y"
+
+    def test_invert_polarity_defaults_false(self):
+        """Both specs default invert_polarity to false."""
+        assert _load_spec(_SPEC_3COL).invert_polarity is False
+        assert _load_spec(_SPEC_4COL).invert_polarity is False
+
+    def test_missing_file_raises_config_error(self):
+        """_load_spec() raises ConfigError for a non-existent path."""
+        with pytest.raises(ConfigError, match="not found"):
+            _load_spec(Path("/nonexistent/spec.toml"))
+
+    def test_missing_section_raises_config_error(self):
+        """_load_spec() raises ConfigError when a required TOML section is absent."""
+        toml_content = b"""
+[meta]
+description = "test"
+source_table = "FlatTransaction"
+
+[export]
+format = "csv"
+split_by_statement = false
+
+[columns]
+Date = "transaction_date"
+
+[format]
+date_format = "%d/%m/%Y"
+float_precision = 2
+invert_polarity = false
+blank_zeros = false
+# [sanitise] section deliberately omitted
+"""
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as fh:
+            fh.write(toml_content)
+            tmp = Path(fh.name)
+        try:
+            with pytest.raises(ConfigError, match="sanitise"):
+                _load_spec(tmp)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_invalid_format_raises_config_error(self):
+        """_load_spec() raises ConfigError when format is not csv or xlsx."""
+        toml_content = b"""
+[meta]
+description = "test"
+source_table = "FlatTransaction"
+
+[export]
+format = "parquet"
+split_by_statement = false
+
+[columns]
+Date = "transaction_date"
+
+[format]
+date_format = "%d/%m/%Y"
+float_precision = 2
+invert_polarity = false
+blank_zeros = false
+
+[sanitise]
+strip_chars = ""
+"""
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as fh:
+            fh.write(toml_content)
+            tmp = Path(fh.name)
+        try:
+            with pytest.raises(ConfigError, match="format"):
+                _load_spec(tmp)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_unknown_computed_token_raises_config_error(self):
+        """_load_spec() raises ConfigError for an unrecognised computed: token."""
+        toml_content = b"""
+[meta]
+description = "test"
+source_table = "FlatTransaction"
+
+[export]
+format = "csv"
+split_by_statement = false
+
+[columns]
+Amount = "computed:unknown_token"
+
+[format]
+date_format = "%d/%m/%Y"
+float_precision = 2
+invert_polarity = false
+blank_zeros = false
+
+[sanitise]
+strip_chars = ""
+"""
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as fh:
+            fh.write(toml_content)
+            tmp = Path(fh.name)
+        try:
+            with pytest.raises(ConfigError, match="computed"):
+                _load_spec(tmp)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_invalid_source_table_raises_config_error(self):
+        """_load_spec() raises ConfigError for a source_table not in the allowed set."""
+        toml_content = b"""
+[meta]
+description = "test"
+source_table = "some_random_table"
+
+[export]
+format = "csv"
+split_by_statement = false
+
+[columns]
+Date = "transaction_date"
+
+[format]
+date_format = "%d/%m/%Y"
+float_precision = 2
+invert_polarity = false
+blank_zeros = false
+
+[sanitise]
+strip_chars = ""
+"""
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as fh:
+            fh.write(toml_content)
+            tmp = Path(fh.name)
+        try:
+            with pytest.raises(ConfigError, match="source_table"):
+                _load_spec(tmp)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# TestExportSpecOutput
+# ---------------------------------------------------------------------------
+
+
+class TestExportSpecOutput:
+    """Verify output file location, naming, and column headers."""
+
+    def test_3column_output_file_exists(self, good_project):
+        """export_spec() creates a non-empty CSV for the 3-column spec."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        assert len(written) == 1
+        assert written[0].exists()
+        assert written[0].stat().st_size > 0
+
+    def test_4column_output_file_exists(self, good_project):
+        """export_spec() creates a non-empty CSV for the 4-column spec."""
+        written = export_spec(_SPEC_4COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        assert len(written) == 1
+        assert written[0].exists()
+        assert written[0].stat().st_size > 0
+
+    def test_output_dir_is_under_export(self, good_project):
+        """Output file lives under export/<spec_stem>/ not export/specs/."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        paths = ProjectPaths.resolve(good_project.project_path)
+        expected_dir = paths.exports / _SPEC_3COL.stem
+        assert written[0].parent == expected_dir
+
+    def test_output_filename_matches_account_key(self, good_project):
+        """Single-file output is named <account_key>.csv."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        assert written[0].name == f"{_ACCOUNT_KEY}.csv"
+
+    def test_3column_headers(self, good_project):
+        """3-column CSV has exactly Date, Description, Amount columns."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        assert df.columns == ["Date", "Description", "Amount"]
+
+    def test_4column_headers(self, good_project):
+        """4-column CSV has exactly Date, Description, Credit, Debit columns."""
+        written = export_spec(_SPEC_4COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0], infer_schema_length=0)
+        assert df.columns == ["Date", "Description", "Credit", "Debit"]
+
+    def test_format_override_xlsx(self, good_project):
+        """Passing format='xlsx' override produces an .xlsx file."""
+        written = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            format="xlsx",
+        )
+        assert len(written) == 1
+        assert written[0].suffix == ".xlsx"
+        assert written[0].exists()
+        assert written[0].stat().st_size > 0
+
+
+# ---------------------------------------------------------------------------
+# TestExportSpecContent
+# ---------------------------------------------------------------------------
+
+
+class TestExportSpecContent:
+    """Verify data content: counts, totals, dates, blanks, polarity."""
+
+    def test_3column_row_count_matches_db(self, good_project):
+        """3-column export row count matches FlatTransaction count for the account."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        expected = _get_flat_transaction_count(good_project.project_path, _ACCOUNT_KEY)
+        assert df.height == expected, f"CSV rows={df.height}, DB rows={expected}"
+
+    def test_4column_row_count_matches_db(self, good_project):
+        """4-column export row count matches FlatTransaction count for the account."""
+        written = export_spec(_SPEC_4COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0], infer_schema_length=0)
+        expected = _get_flat_transaction_count(good_project.project_path, _ACCOUNT_KEY)
+        assert df.height == expected, f"CSV rows={df.height}, DB rows={expected}"
+
+    def test_date_format_is_uk(self, good_project):
+        """All Date values in the 3-column export match dd/mm/yyyy."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        bad = [v for v in df["Date"].to_list() if v is not None and not _DATE_RE.match(str(v))]
+        assert bad == [], f"Non-UK date values found: {bad[:5]}"
+
+    def test_3column_amount_sum_matches_db(self, good_project):
+        """3-column Amount column: SUM equals value_in minus value_out from DB."""
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        csv_sum = df["Amount"].sum() or 0.0
+        db_in = _get_fact_transaction_value_in_sum(good_project.project_path, _ACCOUNT_KEY)
+        db_out = _get_fact_transaction_value_out_sum(good_project.project_path, _ACCOUNT_KEY)
+        expected = db_in - db_out
+        assert abs(csv_sum - expected) < 0.01, f"Amount sum {csv_sum} != expected {expected}"
+
+    def test_invert_polarity_override_negates_amount(self, good_project):
+        """Passing invert_polarity=True negates the Amount column."""
+        written_normal = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+        )
+        # Read immediately before the second call overwrites the same output path.
+        df_normal = pl.read_csv(written_normal[0])
+        normal_sum = df_normal["Amount"].sum() or 0.0
+
+        written_inverted = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            invert_polarity=True,
+        )
+        df_inverted = pl.read_csv(written_inverted[0])
+        inverted_sum = df_inverted["Amount"].sum() or 0.0
+        assert abs(normal_sum + inverted_sum) < 0.01, f"Inverted sum {inverted_sum} should be the negative of normal sum {normal_sum}"
+
+    def test_4column_blank_zeros_credit(self, good_project):
+        """4-column Credit column is blank (empty string) when value_in is 0."""
+        written = export_spec(_SPEC_4COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        # Read as strings to inspect blank cells
+        df = pl.read_csv(written[0], infer_schema_length=0)
+        # For every row, Credit and Debit should not both be non-empty
+        credit_col = df["Credit"].to_list()
+        debit_col = df["Debit"].to_list()
+        both_filled = [
+            i
+            for i, (c, d) in enumerate(zip(credit_col, debit_col))
+            if c not in (None, "", "0.0", "0.00") and d not in (None, "", "0.0", "0.00")
+        ]
+        assert both_filled == [], f"Rows where both Credit and Debit are non-blank (expected at most one): rows {both_filled[:5]}"
+
+    def test_4column_credit_sum_matches_db(self, good_project):
+        """4-column Credit column sum matches value_in from DB."""
+        written = export_spec(_SPEC_4COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        csv_credit = df["Credit"].sum() or 0.0
+        db_in = _get_fact_transaction_value_in_sum(good_project.project_path, _ACCOUNT_KEY)
+        assert abs(csv_credit - db_in) < 0.01, f"Credit sum {csv_credit} != DB value_in {db_in}"
+
+    def test_4column_debit_sum_matches_db(self, good_project):
+        """4-column Debit column sum matches value_out from DB."""
+        written = export_spec(_SPEC_4COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        csv_debit = df["Debit"].sum() or 0.0
+        db_out = _get_fact_transaction_value_out_sum(good_project.project_path, _ACCOUNT_KEY)
+        assert abs(csv_debit - db_out) < 0.01, f"Debit sum {csv_debit} != DB value_out {db_out}"
+
+    def test_strip_chars_removes_special_characters(self, good_project):
+        """Description column contains no characters from strip_chars."""
+        spec = _load_spec(_SPEC_3COL)
+        written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        df = pl.read_csv(written[0])
+        for char in spec.strip_chars:
+            bad_rows = df.filter(pl.col("Description").str.contains(re.escape(char)))
+            assert bad_rows.height == 0, f"Character {char!r} found in Description after sanitisation"
+
+
+# ---------------------------------------------------------------------------
+# TestExportSpecFiltering
+# ---------------------------------------------------------------------------
+
+
+class TestExportSpecFiltering:
+    """Verify date-range, statement_key, and split_by_statement filtering."""
+
+    def test_date_from_reduces_rows(self, good_project):
+        """Passing date_from produces fewer or equal rows than the full export."""
+        written_full = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        written_filtered = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            date_from=date(2022, 1, 1),
+        )
+        df_full = pl.read_csv(written_full[0])
+        df_filtered = pl.read_csv(written_filtered[0])
+        assert df_filtered.height <= df_full.height
+
+    def test_date_to_reduces_rows(self, good_project):
+        """Passing date_to produces fewer or equal rows than the full export."""
+        written_full = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        written_filtered = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            date_to=date(2022, 12, 31),
+        )
+        df_full = pl.read_csv(written_full[0])
+        df_filtered = pl.read_csv(written_filtered[0])
+        assert df_filtered.height <= df_full.height
+
+    def test_date_range_rows_within_bounds(self, good_project):
+        """All dates in a date-filtered export fall within the requested range."""
+        d_from = date(2021, 1, 1)
+        d_to = date(2023, 12, 31)
+        written = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            date_from=d_from,
+            date_to=d_to,
+        )
+        df = pl.read_csv(written[0])
+        if df.height == 0:
+            pytest.skip("No transactions in date range — cannot validate bounds")
+        dates = pl.Series(df["Date"]).str.strptime(pl.Date, "%d/%m/%Y")
+        assert dates.min() >= d_from, f"Earliest date {dates.min()} is before date_from {d_from}"
+        assert dates.max() <= d_to, f"Latest date {dates.max()} is after date_to {d_to}"
+
+    def test_statement_key_filter_returns_subset(self, good_project):
+        """Passing statement_key returns fewer or equal rows than the full export."""
+        statement_ids = _get_statement_ids(good_project.project_path, _ACCOUNT_KEY)
+        assert statement_ids, "No statements found for test account — fixture issue"
+        first_sid = statement_ids[0]
+
+        written_full = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        written_filtered = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            statement_key=first_sid,
+        )
+        df_full = pl.read_csv(written_full[0])
+        df_filtered = pl.read_csv(written_filtered[0])
+        assert df_filtered.height <= df_full.height
+        assert df_filtered.height > 0, f"statement_key={first_sid!r} returned no rows"
+
+    def test_split_by_statement_produces_multiple_files(self, good_project):
+        """split_by_statement=True produces one file per statement."""
+        statement_ids = _get_statement_ids(good_project.project_path, _ACCOUNT_KEY)
+        assert len(statement_ids) > 1, "Need multiple statements to test split — fixture issue"
+
+        written = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            split_by_statement=True,
+        )
+        assert len(written) == len(statement_ids), f"Expected {len(statement_ids)} files, got {len(written)}"
+
+    def test_split_by_statement_filenames(self, good_project):
+        """Each split file is named <account_key>_<id_statement>.csv."""
+        statement_ids = _get_statement_ids(good_project.project_path, _ACCOUNT_KEY)
+        written = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            split_by_statement=True,
+        )
+        expected_stems = {f"{_ACCOUNT_KEY}_{sid}" for sid in statement_ids}
+        actual_stems = {p.stem for p in written}
+        assert actual_stems == expected_stems, f"Stem mismatch.\nExpected: {sorted(expected_stems)}\nActual:   {sorted(actual_stems)}"
+
+    def test_split_files_row_counts_sum_to_total(self, good_project):
+        """Sum of rows across split files equals the total row count."""
+        written_single = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
+        written_split = export_spec(
+            _SPEC_3COL,
+            account_key=_ACCOUNT_KEY,
+            project_path=good_project.project_path,
+            split_by_statement=True,
+        )
+        total_single = pl.read_csv(written_single[0]).height
+        total_split = sum(pl.read_csv(p).height for p in written_split)
+        assert total_split == total_single, f"Split total {total_split} != single-file total {total_single}"

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -161,22 +161,22 @@ class TestDbReports:
 
 # File names produced by ``type="full"`` exports (stem only, no extension).
 _FULL_EXPORT_STEMS = [
-    "statement",
-    "account",
-    "calendar",
-    "transactions",
-    "balances",
-    "gaps",
+    "statement_dimension",
+    "account_dimension",
+    "calendar_dimension",
+    "transaction_measures",
+    "daily_account_balances",
+    "missing_statement_report",
 ]
 
 # Mapping from full-export logical name → DB table/view name (for row-count checks).
 _FULL_STEM_TO_DB_TABLE = {
-    "statement": "DimStatement",
-    "account": "DimAccount",
-    "calendar": "DimTime",
-    "transactions": "FactTransaction",
-    "balances": "FactBalance",
-    "gaps": "GapReport",
+    "statement_dimension": "DimStatement",
+    "account_dimension": "DimAccount",
+    "calendar_dimension": "DimTime",
+    "transaction_measures": "FactTransaction",
+    "daily_account_balances": "FactBalance",
+    "missing_statement_report": "GapReport",
 }
 
 
@@ -205,9 +205,9 @@ class TestExports:
         """DB export_csv(type='simple') writes the flat transactions CSV."""
         db.export_csv(type="simple", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        f = paths.csv / "transactions_table.csv"
-        assert f.exists(), "Missing transactions_table.csv (db/simple)"
-        assert f.stat().st_size > 0, "Empty transactions_table.csv (db/simple)"
+        f = paths.csv / "transactions.csv"
+        assert f.exists(), "Missing transactions.csv (db/simple)"
+        assert f.stat().st_size > 0, "Empty transactions.csv (db/simple)"
 
     # ------------------------------------------------------------------
     # DB backend — CSV content: simple totals
@@ -217,7 +217,7 @@ class TestExports:
         """transactions_table.csv row count and monetary totals match the DB mart."""
         db.export_csv(type="simple", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        df = pl.read_csv(paths.csv / "transactions_table.csv", schema_overrides={"account_number": pl.String})
+        df = pl.read_csv(paths.csv / "transactions.csv", schema_overrides={"account_number": pl.String})
 
         with sqlite3.connect(str(paths.project_db)) as conn:
             db_rows = conn.execute("SELECT COUNT(*) FROM FlatTransaction").fetchone()[0]
@@ -281,9 +281,9 @@ class TestExports:
         """DB export_json(type='simple') writes the flat transactions JSON."""
         db.export_json(type="simple", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        f = paths.json / "transactions_table.json"
-        assert f.exists(), "Missing transactions_table.json (db/simple)"
-        assert f.stat().st_size > 0, "Empty transactions_table.json (db/simple)"
+        f = paths.json / "transactions.json"
+        assert f.exists(), "Missing transactions.json (db/simple)"
+        assert f.stat().st_size > 0, "Empty transactions.json (db/simple)"
 
     # ------------------------------------------------------------------
     # DB backend — JSON content: simple totals
@@ -293,7 +293,7 @@ class TestExports:
         """transactions_table.json row count and monetary totals match the DB mart."""
         db.export_json(type="simple", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        df = pl.read_json(paths.json / "transactions_table.json")
+        df = pl.read_json(paths.json / "transactions.json")
 
         with sqlite3.connect(str(paths.project_db)) as conn:
             db_rows = conn.execute("SELECT COUNT(*) FROM FlatTransaction").fetchone()[0]
@@ -358,20 +358,20 @@ class TestExports:
         # Output should still be written (all three formats, simple preset)
         paths = ProjectPaths.resolve(good_project.project_path)
         assert (paths.excel / "transactions.xlsx").exists()
-        assert (paths.csv / "transactions_table.csv").exists()
-        assert (paths.json / "transactions_table.json").exists()
+        assert (paths.csv / "transactions.csv").exists()
+        assert (paths.json / "transactions.json").exists()
 
     # ------------------------------------------------------------------
     # DB backend — export_reporting_data existence
     # ------------------------------------------------------------------
 
     def test_reporting_data_simple_exists(self, good_project):
-        """export_reporting_data() writes transactions_table.csv to reporting/data/simple/."""
+        """export_reporting_data() writes transactions.csv to reporting/data/simple/."""
         db.export_reporting_data(project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        f = paths.reporting_data_simple / "transactions_table.csv"
-        assert f.exists(), "Missing reporting/data/simple/transactions_table.csv"
-        assert f.stat().st_size > 0, "Empty reporting/data/simple/transactions_table.csv"
+        f = paths.reporting_data_simple / "transactions.csv"
+        assert f.exists(), "Missing reporting/data/simple/transactions.csv"
+        assert f.stat().st_size > 0, "Empty reporting/data/simple/transactions.csv"
 
     def test_reporting_data_full_exists(self, good_project):
         """export_reporting_data() writes all six CSVs to reporting/data/full/."""
@@ -386,7 +386,7 @@ class TestExports:
         """StatementBatch.export(filetype='reporting') populates both reporting directories."""
         good_project.batch.export(filetype="reporting")
         paths = ProjectPaths.resolve(good_project.project_path)
-        assert (paths.reporting_data_simple / "transactions_table.csv").exists()
+        assert (paths.reporting_data_simple / "transactions.csv").exists()
         for stem in _FULL_EXPORT_STEMS:
             assert (paths.reporting_data_full / f"{stem}.csv").exists()
 


### PR DESCRIPTION
## Summary

- Introduces a general-purpose export spec system: TOML files declare source table, column mapping, date/number formatting, string sanitisation, and output options (format, split mode, polarity inversion, blank-zeros)
- Ships two QuickBooks Online UK specs: 3-column (signed amount) and 4-column (separate Credit/Debit columns)
- 39 new tests covering spec loading, output naming/location, column headers, row counts, monetary totals, date format, polarity inversion, blank-zero behaviour, string sanitisation, date-range filtering, statement filtering, and split-by-statement partitioning

## Changes

### New
- `src/bank_statement_parser/modules/export_spec.py` — core engine: `ExportSpec` dataclass, `_load_spec()`, `_build_frame()`, `_apply_column_mapping()`, `_apply_date_format()`, `_apply_blank_zeros()`, `_sanitise_strings()`, `_write_frames()`, and public `export_spec()` entry point
- `src/bank_statement_parser/project/export/specs/quickbooks_3column.toml`
- `src/bank_statement_parser/project/export/specs/quickbooks_4column.toml`
- `tests/test_export_spec.py` — 39 integration tests

### Modified
- `paths.py` — adds `export_specs` property and `export_specs_output(spec_stem)` method; includes `export_specs` in `ensure_dirs()`
- `reports_db.py` — re-exports `export_spec` so it is accessible as `bsp.db.export_spec(...)`
- `tests/test_statements.py` — updates export stem names to match the rename of `_collect_report_frames` output keys already on `dev`

## Notes

- `_build_frame` queries `FactTransaction` directly (joined to `DimStatement` + `DimAccount`) rather than via the `FlatTransaction` view, to avoid a double-join fan-out when `transaction_number` is non-unique across accounts
- `_apply_blank_zeros` uses `df.collect_schema()` to restrict zero-replacement to numeric-typed columns only, avoiding a Polars `ComputeError` on string columns
- All 153 tests pass (`test_export_spec`, `test_statements`, `test_datamart`)