### PR TITLE
refactor: make BASE_CONFIG the config/ root and add explicit config subfolder properties

### DIFF
--- a/src/bank_statement_parser/modules/anonymise.py
+++ b/src/bank_statement_parser/modules/anonymise.py
@@ -83,14 +83,14 @@ from bank_statement_parser.modules._anonymise_shared import (
     _parse_tounicode_cmap,
     _rewrite_page_content_stream,
 )
-from bank_statement_parser.modules.paths import BASE_CONFIG
+from bank_statement_parser.modules.paths import BASE_CONFIG_USER
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-# Default config path.
-_DEFAULT_CONFIG_PATH: Path = BASE_CONFIG / "anonymise.toml"
+# Default config path — looks for anonymise.toml in the user config subfolder.
+_DEFAULT_CONFIG_PATH: Path = BASE_CONFIG_USER / "anonymise.toml"
 
 # Digit characters as a frozenset for fast membership test.
 _DIGITS: frozenset[str] = frozenset("0123456789")
@@ -141,7 +141,7 @@ def _load_config(config_path: Path) -> _AnonymiseConfig:
     """
     if not config_path.exists():
         raise FileNotFoundError(
-            f"anonymise.toml not found at {config_path}.\nCopy project/config/user/anonymise_example.toml to project/config/import/anonymise.toml and fill in your exclusions."
+            f"anonymise.toml not found at {config_path}.\nCopy project/config/user/anonymise_example.toml to project/config/user/anonymise.toml and fill in your exclusions."
         )
 
     with config_path.open("rb") as fh:

--- a/src/bank_statement_parser/modules/config.py
+++ b/src/bank_statement_parser/modules/config.py
@@ -26,7 +26,7 @@ from bank_statement_parser.modules.data import (
     StatementType,
 )
 from bank_statement_parser.modules.errors import ConfigError, ProjectConfigMissing, StatementError
-from bank_statement_parser.modules.paths import BASE_CONFIG, ProjectPaths
+from bank_statement_parser.modules.paths import BASE_CONFIG_IMPORT, ProjectPaths
 from bank_statement_parser.modules.statement_functions import get_results
 
 
@@ -85,7 +85,7 @@ def copy_default_config(destination: Path, overwrite: bool = False) -> list[Path
     destination.mkdir(parents=True, exist_ok=True)
 
     copied: list[Path] = []
-    for src in BASE_CONFIG.glob("*.toml"):
+    for src in BASE_CONFIG_IMPORT.glob("*.toml"):
         dst = destination / src.name
         if dst.exists() and not overwrite:
             continue
@@ -122,8 +122,8 @@ class ConfigManager:
 
         Args:
             project_path: Optional Path to the project root directory.
-                          Config files are read from ``project_path / "config"``.
-                          If None, falls back to the shipped ``BASE_CONFIG``
+                          Config files are read from ``project_path / "config" / "import"``.
+                          If None, falls back to the shipped ``BASE_CONFIG_IMPORT``
                           directory bundled with the package.
         """
         self._project_path = project_path
@@ -134,10 +134,10 @@ class ConfigManager:
 
     @property
     def config_dir(self) -> Path:
-        """Return the effective configuration directory path."""
+        """Return the effective configuration directory path (``config/import/``)."""
         if self._project_path is not None:
-            return ProjectPaths.resolve(self._project_path).config
-        return BASE_CONFIG
+            return ProjectPaths.resolve(self._project_path).config_import
+        return BASE_CONFIG_IMPORT
 
     @property
     def config_dict(self) -> dict:

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -21,8 +21,14 @@ _BSP = Path(__file__).parent.parent
 # The default project root bundled with the package.
 _DEFAULT_PROJECT_ROOT: Path = _BSP.joinpath("project")
 
-# Base config lives inside the default project's config/import sub-directory.
-BASE_CONFIG = _DEFAULT_PROJECT_ROOT / "config" / "import"
+# Root config directory bundled with the package.
+BASE_CONFIG = _DEFAULT_PROJECT_ROOT / "config"
+
+# Config sub-directory constants — each maps to one of the four config subfolders.
+BASE_CONFIG_IMPORT = BASE_CONFIG / "import"  # Bank statement parsing TOML configs.
+BASE_CONFIG_EXPORT = BASE_CONFIG / "export"  # Export spec TOML files.
+BASE_CONFIG_REPORT = BASE_CONFIG / "report"  # Report config (reserved).
+BASE_CONFIG_USER = BASE_CONFIG / "user"  # User-specific config (e.g. anonymise.toml).
 
 # The modules directory (used by a few internal references).
 MODULES = _BSP.joinpath("modules")
@@ -58,7 +64,6 @@ class ProjectPaths:
               simple/  full/
           log/
             debug/
-
     Use :meth:`resolve` to obtain an instance rather than instantiating
     this class directly.
     """
@@ -70,9 +75,29 @@ class ProjectPaths:
     # ------------------------------------------------------------------
 
     @property
-    def config(self) -> Path:
-        """Directory containing import TOML config files (``config/import/``)."""
-        return self.root / "config" / "import"
+    def config_root(self) -> Path:
+        """Root config directory (``config/``)."""
+        return self.root / "config"
+
+    @property
+    def config_import(self) -> Path:
+        """Directory containing TOML configs for parsing bank statements (``config/import/``)."""
+        return self.config_root / "import"
+
+    @property
+    def config_export(self) -> Path:
+        """Directory containing export spec TOML files (``config/export/``)."""
+        return self.config_root / "export"
+
+    @property
+    def config_report(self) -> Path:
+        """Directory for report config files — reserved for future use (``config/report/``)."""
+        return self.config_root / "report"
+
+    @property
+    def config_user(self) -> Path:
+        """Directory for user-specific config files, e.g. ``anonymise.toml`` (``config/user/``)."""
+        return self.config_root / "user"
 
     @property
     def parquet(self) -> Path:
@@ -104,7 +129,7 @@ class ProjectPaths:
     @property
     def export_specs(self) -> Path:
         """Directory containing export spec TOML files (``config/export/``)."""
-        return self.root / "config" / "export"
+        return self.config_export
 
     def export_specs_output(self, spec_stem: str) -> Path:
         """Output directory for a named export spec (``export/<spec_stem>/``).
@@ -167,7 +192,7 @@ class ProjectPaths:
     @property
     def forex_config(self) -> Path:
         """Path to the optional forex API config file."""
-        return self.config / "forex_api_config.toml"
+        return self.config_import / "forex_api_config.toml"
 
     # ------------------------------------------------------------------
     # Permanent Parquet files
@@ -289,16 +314,15 @@ class ProjectPaths:
     def ensure_dirs(self) -> None:
         """Create all project sub-directories if they do not already exist."""
         for directory in (
-            self.config,
-            self.root / "config" / "export",
-            self.root / "config" / "report",
-            self.root / "config" / "user",
+            self.config_import,
+            self.config_export,
+            self.config_report,
+            self.config_user,
             self.parquet,
             self.database,
             self.csv,
             self.excel,
             self.json,
-            self.export_specs,
             self.reporting_data_simple,
             self.reporting_data_full,
             self.log_debug,
@@ -418,7 +442,7 @@ def validate_or_initialise_project(project_path: Path) -> None:
 
     paths = ProjectPaths.resolve(project_path)
 
-    has_toml = paths.config.is_dir() and bool(list(paths.config.rglob("*.toml")))
+    has_toml = paths.config_import.is_dir() and bool(list(paths.config_import.rglob("*.toml")))
     has_db = paths.project_db.exists()
 
     # Rule 2: neither present → new project, scaffold in full.
@@ -438,7 +462,7 @@ def validate_or_initialise_project(project_path: Path) -> None:
 
     # Rule 4: DB present but config missing → corrupted/partial project.
     if has_db and not has_toml:
-        raise ProjectConfigMissing(paths.config)
+        raise ProjectConfigMissing(paths.config_import)
 
     # Rule 5: both present → valid, nothing to do.
 
@@ -479,9 +503,9 @@ def _scaffold_new_project(paths: ProjectPaths) -> None:
     paths.ensure_dirs()
 
     # 2. Copy default TOML config files (including any company subfolders).
-    for src in BASE_CONFIG.rglob("*.toml"):
-        relative = src.relative_to(BASE_CONFIG)
-        dst = paths.config / relative
+    for src in BASE_CONFIG_IMPORT.rglob("*.toml"):
+        relative = src.relative_to(BASE_CONFIG_IMPORT)
+        dst = paths.config_import / relative
         dst.parent.mkdir(parents=True, exist_ok=True)
         if not dst.exists():
             shutil.copy2(src, dst)


### PR DESCRIPTION
## Summary

- `BASE_CONFIG` is now the `project/config/` root directory (was `config/import/`)
- Four new module-level constants give explicit access to each subfolder: `BASE_CONFIG_IMPORT`, `BASE_CONFIG_EXPORT`, `BASE_CONFIG_REPORT`, `BASE_CONFIG_USER`
- `ProjectPaths.config` (implicit alias for `import/`) replaced by four explicit properties: `config_root`, `config_import`, `config_export`, `config_report`, `config_user`
- `anonymise.toml` moved to `config/user/` in the previous PR; `anonymise.py` now looks there by default via `BASE_CONFIG_USER`

## Files changed

| File | Change |
| --- | --- |
| `modules/paths.py` | `BASE_CONFIG` → `config/` root; add `BASE_CONFIG_IMPORT/EXPORT/REPORT/USER` constants; replace `config` property with `config_root`, `config_import`, `config_export`, `config_report`, `config_user`; update `export_specs`, `forex_config`, `ensure_dirs`, `validate_or_initialise_project`, `_scaffold_new_project` |
| `modules/anonymise.py` | Import `BASE_CONFIG_USER`; `_DEFAULT_CONFIG_PATH` → `config/user/anonymise.toml`; update error message hint |
| `modules/config.py` | Import `BASE_CONFIG_IMPORT`; `copy_default_config` and `ConfigManager.config_dir` use `BASE_CONFIG_IMPORT` / `config_import` |
| `docs/` | Regenerated |

## Tests

All 202 tests pass.