### PR TITLE
refactor: expand path constants and rename ProjectPaths properties

### DIFF
--- a/src/bank_statement_parser/modules/anonymise.py
+++ b/src/bank_statement_parser/modules/anonymise.py
@@ -83,14 +83,14 @@ from bank_statement_parser.modules._anonymise_shared import (
     _parse_tounicode_cmap,
     _rewrite_page_content_stream,
 )
-from bank_statement_parser.modules.paths import BASE_CONFIG
+from bank_statement_parser.modules.paths import BASE_CONFIG_USER
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
 # Default config path.
-_DEFAULT_CONFIG_PATH: Path = BASE_CONFIG / "anonymise.toml"
+_DEFAULT_CONFIG_PATH: Path = BASE_CONFIG_USER / "anonymise.toml"
 
 # Digit characters as a frozenset for fast membership test.
 _DIGITS: frozenset[str] = frozenset("0123456789")

--- a/src/bank_statement_parser/modules/config.py
+++ b/src/bank_statement_parser/modules/config.py
@@ -26,7 +26,7 @@ from bank_statement_parser.modules.data import (
     StatementType,
 )
 from bank_statement_parser.modules.errors import ConfigError, ProjectConfigMissing, StatementError
-from bank_statement_parser.modules.paths import BASE_CONFIG, ProjectPaths
+from bank_statement_parser.modules.paths import BASE_CONFIG_IMPORT, ProjectPaths
 from bank_statement_parser.modules.statement_functions import get_results
 
 
@@ -85,7 +85,7 @@ def copy_default_config(destination: Path, overwrite: bool = False) -> list[Path
     destination.mkdir(parents=True, exist_ok=True)
 
     copied: list[Path] = []
-    for src in BASE_CONFIG.glob("*.toml"):
+    for src in BASE_CONFIG_IMPORT.glob("*.toml"):
         dst = destination / src.name
         if dst.exists() and not overwrite:
             continue
@@ -123,7 +123,7 @@ class ConfigManager:
         Args:
             project_path: Optional Path to the project root directory.
                           Config files are read from ``project_path / "config"``.
-                          If None, falls back to the shipped ``BASE_CONFIG``
+                          If None, falls back to the shipped ``BASE_CONFIG_IMPORT``
                           directory bundled with the package.
         """
         self._project_path = project_path
@@ -136,8 +136,8 @@ class ConfigManager:
     def config_dir(self) -> Path:
         """Return the effective configuration directory path."""
         if self._project_path is not None:
-            return ProjectPaths.resolve(self._project_path).config
-        return BASE_CONFIG
+            return ProjectPaths.resolve(self._project_path).config_import
+        return BASE_CONFIG_IMPORT
 
     @property
     def config_dict(self) -> dict:

--- a/src/bank_statement_parser/modules/export_spec.py
+++ b/src/bank_statement_parser/modules/export_spec.py
@@ -599,7 +599,7 @@ def export_spec(
     lf = _apply_blank_zeros(lf, loaded)
     lf = _sanitise_strings(lf, loaded)
 
-    output_dir = paths.export_specs_output(spec.stem)
+    output_dir = paths.export_output(spec.stem)
     paths.ensure_subdir_for_write(output_dir)
 
     if not loaded.split_by_statement:

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -1,3 +1,19 @@
+"""
+paths — file-system layout constants and ProjectPaths factory.
+
+Module-level constants and the :class:`ProjectPaths` dataclass that derives
+every runtime path from a single project root directory.
+
+Constants:
+    BASE_CONFIG: Root of the default project's ``config/`` directory.
+    BASE_CONFIG_IMPORT: Default ``config/import/`` directory (bank-parsing TOMLs).
+    BASE_CONFIG_EXPORT: Default ``config/export/`` directory (export spec files).
+    BASE_CONFIG_REPORT: Default ``config/report/`` directory (report config).
+    BASE_CONFIG_USER: Default ``config/user/`` directory (user-specific config).
+    MODULES: The ``modules/`` directory inside the installed package.
+    DATA: The ``data/`` directory inside the installed package.
+"""
+
 from __future__ import annotations
 
 import shutil
@@ -21,8 +37,14 @@ _BSP = Path(__file__).parent.parent
 # The default project root bundled with the package.
 _DEFAULT_PROJECT_ROOT: Path = _BSP.joinpath("project")
 
-# Base config lives inside the default project's config/import sub-directory.
-BASE_CONFIG = _DEFAULT_PROJECT_ROOT / "config" / "import"
+# Root of the default project's config/ directory.
+BASE_CONFIG: Path = _DEFAULT_PROJECT_ROOT / "config"
+
+# Sub-directory constants beneath BASE_CONFIG.
+BASE_CONFIG_IMPORT: Path = BASE_CONFIG / "import"
+BASE_CONFIG_EXPORT: Path = BASE_CONFIG / "export"
+BASE_CONFIG_REPORT: Path = BASE_CONFIG / "report"
+BASE_CONFIG_USER: Path = BASE_CONFIG / "user"
 
 # The modules directory (used by a few internal references).
 MODULES = _BSP.joinpath("modules")
@@ -70,9 +92,29 @@ class ProjectPaths:
     # ------------------------------------------------------------------
 
     @property
-    def config(self) -> Path:
+    def config_root(self) -> Path:
+        """Root config directory (``config/``)."""
+        return self.root / "config"
+
+    @property
+    def config_import(self) -> Path:
         """Directory containing import TOML config files (``config/import/``)."""
-        return self.root / "config" / "import"
+        return self.config_root / "import"
+
+    @property
+    def config_export(self) -> Path:
+        """Directory containing export spec files (``config/export/``)."""
+        return self.config_root / "export"
+
+    @property
+    def config_report(self) -> Path:
+        """Directory containing report config files (``config/report/``)."""
+        return self.config_root / "report"
+
+    @property
+    def config_user(self) -> Path:
+        """Directory containing user-specific config files (``config/user/``)."""
+        return self.config_root / "user"
 
     @property
     def parquet(self) -> Path:
@@ -102,11 +144,11 @@ class ProjectPaths:
         return self.exports / "json"
 
     @property
-    def export_specs(self) -> Path:
-        """Directory containing export spec TOML files (``config/export/``)."""
-        return self.root / "config" / "export"
+    def export_config(self) -> Path:
+        """Directory containing export spec files (``config/export/``)."""
+        return self.config_export
 
-    def export_specs_output(self, spec_stem: str) -> Path:
+    def export_output(self, spec_stem: str) -> Path:
         """Output directory for a named export spec (``export/<spec_stem>/``).
 
         Args:
@@ -167,7 +209,7 @@ class ProjectPaths:
     @property
     def forex_config(self) -> Path:
         """Path to the optional forex API config file."""
-        return self.config / "forex_api_config.toml"
+        return self.config_import / "forex_api_config.toml"
 
     # ------------------------------------------------------------------
     # Permanent Parquet files
@@ -289,16 +331,16 @@ class ProjectPaths:
     def ensure_dirs(self) -> None:
         """Create all project sub-directories if they do not already exist."""
         for directory in (
-            self.config,
-            self.root / "config" / "export",
-            self.root / "config" / "report",
-            self.root / "config" / "user",
+            self.config_import,
+            self.config_export,
+            self.config_report,
+            self.config_user,
             self.parquet,
             self.database,
             self.csv,
             self.excel,
             self.json,
-            self.export_specs,
+            self.export_config,
             self.reporting_data_simple,
             self.reporting_data_full,
             self.log_debug,
@@ -418,7 +460,7 @@ def validate_or_initialise_project(project_path: Path) -> None:
 
     paths = ProjectPaths.resolve(project_path)
 
-    has_toml = paths.config.is_dir() and bool(list(paths.config.rglob("*.toml")))
+    has_toml = paths.config_import.is_dir() and bool(list(paths.config_import.rglob("*.toml")))
     has_db = paths.project_db.exists()
 
     # Rule 2: neither present → new project, scaffold in full.
@@ -438,7 +480,7 @@ def validate_or_initialise_project(project_path: Path) -> None:
 
     # Rule 4: DB present but config missing → corrupted/partial project.
     if has_db and not has_toml:
-        raise ProjectConfigMissing(paths.config)
+        raise ProjectConfigMissing(paths.config_import)
 
     # Rule 5: both present → valid, nothing to do.
 
@@ -479,9 +521,9 @@ def _scaffold_new_project(paths: ProjectPaths) -> None:
     paths.ensure_dirs()
 
     # 2. Copy default TOML config files (including any company subfolders).
-    for src in BASE_CONFIG.rglob("*.toml"):
-        relative = src.relative_to(BASE_CONFIG)
-        dst = paths.config / relative
+    for src in BASE_CONFIG_IMPORT.rglob("*.toml"):
+        relative = src.relative_to(BASE_CONFIG_IMPORT)
+        dst = paths.config_import / relative
         dst.parent.mkdir(parents=True, exist_ok=True)
         if not dst.exists():
             shutil.copy2(src, dst)


### PR DESCRIPTION
## Summary

- Renames `BASE_CONFIG` from pointing at `config/import/` to the `config/` root, making its meaning unambiguous.
- Adds four sub-directory constants: `BASE_CONFIG_IMPORT`, `BASE_CONFIG_EXPORT`, `BASE_CONFIG_REPORT`, `BASE_CONFIG_USER`.
- Renames `ProjectPaths` properties:
  - `config` → `config_import`
  - `export_specs` → `export_config`
  - `export_specs_output(stem)` → `export_output(stem)`
- Adds new `ProjectPaths` properties: `config_root`, `config_export`, `config_report`, `config_user`.
- Updates all callers (`anonymise.py`, `config.py`, `export_spec.py`, `paths.py` internals) to use the new names.
- Adds a module-level docstring to `paths.py`.

## Motivation

Prerequisite for PR B (`feat/sql-export-files`), which places `.sql` files alongside `.toml` export specs in `config/export/`. The new constants and properties give the rest of the codebase clean, unambiguous handles for each config sub-directory.

## Tests

202/202 passing. Ruff clean.