### PR TITLE
refactor: rename config.py → import_config.py, standardise Path construction, fix rglob bug

### DIFF
--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -141,11 +141,11 @@ Re-process all failing statements from a completed batch and write debug files.
 
 ## Config helpers
 
-### `bsp.copy_default_config()`
+### `bsp.copy_default_import_config()`
 
-*function* — `bank_statement_parser.modules.config`
+*function* — `bank_statement_parser.modules.import_config`
 
-Copy all default TOML configuration files to a destination directory.
+Copy all default import TOML configuration files to a destination directory.
 
 ### `bsp.copy_project_folders()`
 

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -112,7 +112,7 @@ from bank_statement_parser.modules.errors import (
 # ---------------------------------------------------------------------------
 # Config helpers
 # ---------------------------------------------------------------------------
-from bank_statement_parser.modules.config import copy_default_config
+from bank_statement_parser.modules.import_config import copy_default_import_config
 from bank_statement_parser.modules.paths import ProjectPaths, copy_project_folders, validate_or_initialise_project
 
 # ---------------------------------------------------------------------------
@@ -177,7 +177,7 @@ __all__ = [
     "ProjectDatabaseMissing",
     "ProjectConfigMissing",
     # Config helpers
-    "copy_default_config",
+    "copy_default_import_config",
     "copy_project_folders",
     "validate_or_initialise_project",
     "ProjectPaths",

--- a/src/bank_statement_parser/data/build_datamart.py
+++ b/src/bank_statement_parser/data/build_datamart.py
@@ -714,11 +714,13 @@ def build_datamart(db_path: Path, verbose: bool = True) -> dict:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    from bank_statement_parser.modules.paths import ProjectPaths  # noqa: PLC0415
+
     parser = argparse.ArgumentParser(description="Build (or rebuild) the data mart tables from raw source data.")
     parser.add_argument(
         "--db",
         type=Path,
-        default=Path(__file__).parent.parent / "project" / "database" / "project.db",
+        default=ProjectPaths.resolve().project_db,
         help="Path to the SQLite database (default: project.db)",
     )
     parser.add_argument(

--- a/src/bank_statement_parser/data/create_project_db.py
+++ b/src/bank_statement_parser/data/create_project_db.py
@@ -210,4 +210,6 @@ def create_indexes(db_path: Path):
 
 
 if __name__ == "__main__":
-    main(db_path=Path(__file__).parent.parent.joinpath("project", "database", "project.db"), with_fk=True)
+    from bank_statement_parser.modules.paths import ProjectPaths  # noqa: PLC0415
+
+    main(db_path=ProjectPaths.resolve().project_db, with_fk=True)

--- a/src/bank_statement_parser/data/create_project_db_views.py
+++ b/src/bank_statement_parser/data/create_project_db_views.py
@@ -272,4 +272,6 @@ def create_views(db_path: Path):
 
 
 if __name__ == "__main__":
-    create_views(Path(__file__).parent.parent.joinpath("project", "database", "project.db"))
+    from bank_statement_parser.modules.paths import ProjectPaths  # noqa: PLC0415
+
+    create_views(ProjectPaths.resolve().project_db)

--- a/src/bank_statement_parser/data/housekeeping.py
+++ b/src/bank_statement_parser/data/housekeeping.py
@@ -187,6 +187,8 @@ class Housekeeping:
 
 
 if __name__ == "__main__":
+    from bank_statement_parser.modules.paths import ProjectPaths  # noqa: PLC0415
+
     parser = argparse.ArgumentParser(description="Database integrity housekeeping")
     parser.add_argument(
         "--delete",
@@ -196,7 +198,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--db",
         type=Path,
-        default=Path(__file__).parent.parent.joinpath("project", "database", "project.db"),
+        default=ProjectPaths.resolve().project_db,
         help="Path to database file",
     )
     args = parser.parse_args()

--- a/src/bank_statement_parser/data/mock_project_data.py
+++ b/src/bank_statement_parser/data/mock_project_data.py
@@ -267,8 +267,10 @@ def generate_mock_data(db_path: Path, num_batches: int = 10, statements_per_batc
 
 
 if __name__ == "__main__":
+    from bank_statement_parser.modules.paths import ProjectPaths  # noqa: PLC0415
+
     generate_mock_data(
-        db_path=Path(__file__).parent.parent.joinpath("project", "database", "project.db"),
+        db_path=ProjectPaths.resolve().project_db,
         num_batches=10,
         statements_per_batch=20,
         transactions_per_statement=50,

--- a/src/bank_statement_parser/modules/__init__.py
+++ b/src/bank_statement_parser/modules/__init__.py
@@ -24,7 +24,7 @@ functions.  Access them via the namespace:
 """
 
 import bank_statement_parser.modules.reports_db as db
-from bank_statement_parser.modules.config import copy_default_config
+from bank_statement_parser.modules.import_config import copy_default_import_config
 from bank_statement_parser.modules.paths import copy_project_folders
 from bank_statement_parser.modules.data import Failure, ParquetFiles, PdfResult, Review, StatementInfo, Success
 from bank_statement_parser.modules.errors import StatementError
@@ -49,7 +49,7 @@ __all__ = [
     "ParquetFiles",
     "delete_temp_files",
     # Config helpers
-    "copy_default_config",
+    "copy_default_import_config",
     "copy_project_folders",
     # Errors
     "StatementError",

--- a/src/bank_statement_parser/modules/anonymise.py
+++ b/src/bank_statement_parser/modules/anonymise.py
@@ -90,7 +90,7 @@ from bank_statement_parser.modules.paths import BASE_CONFIG_USER
 # ---------------------------------------------------------------------------
 
 # Default config path — looks for anonymise.toml in the user config subfolder.
-_DEFAULT_CONFIG_PATH: Path = BASE_CONFIG_USER / "anonymise.toml"
+_DEFAULT_CONFIG_PATH: Path = BASE_CONFIG_USER.joinpath("anonymise.toml")
 
 # Digit characters as a frozenset for fast membership test.
 _DIGITS: frozenset[str] = frozenset("0123456789")

--- a/src/bank_statement_parser/modules/import_config.py
+++ b/src/bank_statement_parser/modules/import_config.py
@@ -1,8 +1,12 @@
 """
-Configuration management for bank statement parsing.
+Import configuration management for bank statement parsing.
 
-This module provides ConfigManager class for loading and accessing TOML-based
-configuration files, as well as backward-compatible module-level functions.
+This module provides :class:`ImportConfigManager` for loading and accessing
+TOML-based configuration files that drive the bank-statement import pipeline
+(companies, accounts, statement types, statement tables, standard fields).
+
+Configuration files live under ``<project>/config/import/``.  The shipped
+defaults are in ``src/bank_statement_parser/project/config/import/``.
 """
 
 import shutil
@@ -37,7 +41,7 @@ class _ConfigEntry(TypedDict):
     config: dict[str, Any]
 
 
-REQUIRED_CONFIG_FILES = [
+REQUIRED_CONFIG_FILES: list[str] = [
     "companies.toml",
     "account_types.toml",
     "accounts.toml",
@@ -47,15 +51,18 @@ REQUIRED_CONFIG_FILES = [
 ]
 
 
-def copy_default_config(destination: Path, overwrite: bool = False) -> list[Path]:
+def copy_default_import_config(destination: Path, overwrite: bool = False) -> list[Path]:
     """
-    Copy all default TOML configuration files to a destination directory.
+    Copy all default import TOML configuration files to a destination directory.
 
-    Copies every ``*.toml`` file from the shipped ``base_config`` folder into
-    *destination*, creating the directory (and any parents) if it does not
-    already exist.  The copied files are the starting-point for a user config
-    override: place the returned files in ``<project_path>/config/`` and pass
-    that project root as ``project_path`` to ``ConfigManager`` (or
+    Copies every ``*.toml`` file (including company sub-directories) from the
+    shipped ``base_config/import`` folder into *destination*, preserving the
+    relative directory structure.  The destination directory (and any parents)
+    are created if they do not already exist.
+
+    The copied files are the starting-point for a user config override: place
+    the returned files in ``<project_path>/config/import/`` and pass that
+    project root as ``project_path`` to :class:`ImportConfigManager` (or
     ``Statement``/``StatementBatch``) to override the built-in defaults.
 
     Args:
@@ -75,7 +82,7 @@ def copy_default_config(destination: Path, overwrite: bool = False) -> list[Path
         import bank_statement_parser as bsp
         from pathlib import Path
 
-        copied = bsp.copy_default_config(Path("my_project/config/import"))
+        copied = bsp.copy_default_import_config(Path("my_project/config/import"))
         # Edit the TOML files, then:
         batch = bsp.StatementBatch(pdfs=[...], project_path=Path("my_project"))
     """
@@ -85,8 +92,10 @@ def copy_default_config(destination: Path, overwrite: bool = False) -> list[Path
     destination.mkdir(parents=True, exist_ok=True)
 
     copied: list[Path] = []
-    for src in BASE_CONFIG_IMPORT.glob("*.toml"):
-        dst = destination / src.name
+    for src in BASE_CONFIG_IMPORT.rglob("*.toml"):
+        relative = src.relative_to(BASE_CONFIG_IMPORT)
+        dst = destination.joinpath(relative)
+        dst.parent.mkdir(parents=True, exist_ok=True)
         if dst.exists() and not overwrite:
             continue
         shutil.copy2(src, dst)
@@ -95,13 +104,13 @@ def copy_default_config(destination: Path, overwrite: bool = False) -> list[Path
     return copied
 
 
-class ConfigManager:
+class ImportConfigManager:
     """
-    Manages configuration loading and access for bank statement parsing.
+    Manages import configuration loading and access for bank statement parsing.
 
-    This class handles loading TOML configuration files, converting them to
-    dataclasses, linking references between config objects, and providing
-    access to account, company, and statement type configurations.
+    Loads TOML configuration files from ``<project>/config/import/``, converts
+    them to dataclasses, links cross-section references, and provides lookup
+    methods for accounts, companies, and statement types.
 
     Attributes:
         _project_path: Optional project root directory path.
@@ -111,36 +120,40 @@ class ConfigManager:
         _companies_df: Lazy-loaded DataFrame of companies.
 
     Example:
-        >>> config = ConfigManager()
+        >>> config = ImportConfigManager()
         >>> account = config.get_account("my_account")
         >>> accounts = config.get_accounts_for_company("my_company")
     """
 
-    def __init__(self, project_path: Path | None = None):
+    __slots__ = ("_project_path", "_config_dict", "_accounts_df", "_statement_types_df", "_companies_df")
+
+    def __init__(self, project_path: Path | None = None) -> None:
         """
-        Initialize ConfigManager with optional project path.
+        Initialise ImportConfigManager with an optional project path.
 
         Args:
             project_path: Optional Path to the project root directory.
-                          Config files are read from ``project_path / "config" / "import"``.
-                          If None, falls back to the shipped ``BASE_CONFIG_IMPORT``
-                          directory bundled with the package.
+                          Config files are read from
+                          ``project_path / "config" / "import"``.
+                          If ``None``, falls back to the shipped
+                          ``BASE_CONFIG_IMPORT`` directory bundled with the
+                          package.
         """
-        self._project_path = project_path
-        self._config_dict: dict | None = None
+        self._project_path: Path | None = project_path
+        self._config_dict: dict[str, _ConfigEntry] | None = None
         self._accounts_df: pl.DataFrame | None = None
         self._statement_types_df: pl.DataFrame | None = None
         self._companies_df: pl.DataFrame | None = None
 
     @property
     def config_dir(self) -> Path:
-        """Return the effective configuration directory path (``config/import/``)."""
+        """Return the effective import configuration directory path."""
         if self._project_path is not None:
             return ProjectPaths.resolve(self._project_path).config_import
         return BASE_CONFIG_IMPORT
 
     @property
-    def config_dict(self) -> dict:
+    def config_dict(self) -> dict[str, _ConfigEntry]:
         """Return the full configuration dictionary, loading if necessary."""
         if self._config_dict is None:
             self._load_config()
@@ -191,19 +204,19 @@ class ConfigManager:
 
     def _require_config_dir(self) -> None:
         """
-        Validate that the project config directory exists and contains .toml files.
+        Validate that the project import config directory exists and contains .toml files.
 
         Only called when ``_project_path`` is not ``None``.  The project is
         expected to have been initialised already (by
         :func:`~bank_statement_parser.modules.paths.validate_or_initialise_project`
         called from ``Statement`` or ``StatementBatch``).
 
-        Scans both the root config directory and any immediate company
+        Scans both the root config/import directory and any immediate company
         subdirectories for ``.toml`` files.
 
         Raises:
-            ProjectConfigMissing: If ``config/`` is absent or contains no
-                ``.toml`` files at any level.
+            ProjectConfigMissing: If ``config/import/`` is absent or contains
+                no ``.toml`` files at any level.
         """
         config_dir = self.config_dir
         if not config_dir.is_dir() or not list(config_dir.rglob("*.toml")):
@@ -214,11 +227,11 @@ class ConfigManager:
         Load and parse all TOML configuration files.
 
         For each config section, loads the root-level file (e.g.
-        ``config/account_types.toml``) if present, then discovers and merges
-        all matching files from immediate company subdirectories (e.g.
-        ``config/HSBC_UK/accounts.toml``, ``config/TSB_UK/accounts.toml``).
-        All top-level TOML keys must be unique across files; no key may appear
-        in more than one file for the same section.
+        ``config/import/account_types.toml``) if present, then discovers and
+        merges all matching files from immediate company subdirectories (e.g.
+        ``config/import/HSBC_UK/accounts.toml``).  All top-level TOML keys
+        must be unique across files; no key may appear in more than one file
+        for the same section.
 
         Converts raw TOML data to dataclasses and links cross-section
         references between statement tables and account objects.
@@ -238,11 +251,11 @@ class ConfigManager:
         for key in config_dict:
             file_name = f"{key}.toml"
             # Load root-level file first (e.g. account_types.toml, standard_fields.toml)
-            self._merge_toml_file(config_dict, key, self.config_dir / file_name)
+            self._merge_toml_file(config_dict, key, self.config_dir.joinpath(file_name))
             # Load matching files from each immediate company subdirectory
             for subdir in sorted(self.config_dir.iterdir()):
                 if subdir.is_dir():
-                    self._merge_toml_file(config_dict, key, subdir / file_name)
+                    self._merge_toml_file(config_dict, key, subdir.joinpath(file_name))
 
         for v in config_dict.values():
             for k in v["config"]:
@@ -277,8 +290,12 @@ class ConfigManager:
         """
         Link statement table configurations to their parent statement types.
 
-        For each statement type header and lines config that has a statement_table_key,
-        resolves the actual StatementTable object from the config dictionary.
+        For each statement type header and lines config that has a
+        ``statement_table_key``, resolves the actual :class:`StatementTable`
+        object from the config dictionary.
+
+        Args:
+            config_dict: The fully loaded (but not yet linked) config dictionary.
         """
         for key, statement_type in config_dict["statement_types"]["config"].items():
             for config_group in [statement_type.header.configs, statement_type.lines.configs]:
@@ -291,10 +308,13 @@ class ConfigManager:
         """
         Link account objects to their corresponding account type, statement type, and company.
 
-        Populates the account_type, statement_type, and company attributes on each
-        Account object by looking up the referenced keys.  Also validates that
-        ``account.currency`` is a recognised ISO 4217 code present in
-        ``currency_spec``.
+        Populates the ``account_type``, ``statement_type``, and ``company``
+        attributes on each :class:`Account` object by looking up the referenced
+        keys.  Also validates that ``account.currency`` is a recognised ISO 4217
+        code present in ``currency_spec``.
+
+        Args:
+            config_dict: The fully loaded (but not yet linked) config dictionary.
 
         Raises:
             ConfigError: If ``account.currency`` is not a key in ``currency_spec``.
@@ -317,7 +337,7 @@ class ConfigManager:
             account_key: The unique identifier for the account.
 
         Returns:
-            The Account object if found, None otherwise.
+            The Account object if found, ``None`` otherwise.
         """
         return self.accounts.get(account_key)
 
@@ -341,7 +361,7 @@ class ConfigManager:
             company_key: The unique identifier for the company.
 
         Returns:
-            The Company object if found, None otherwise.
+            The Company object if found, ``None`` otherwise.
         """
         return self.companies.get(company_key)
 
@@ -350,7 +370,7 @@ class ConfigManager:
         Identify the company and account from a PDF bank statement.
 
         Attempts to match the PDF against known company configurations by
-        looking for identifying text patterns. Returns the matched account
+        looking for identifying text patterns.  Returns the matched account
         and company key.
 
         Args:
@@ -460,7 +480,7 @@ class ConfigManager:
         """
         Fully identify both company and account from a PDF statement.
 
-        This is the main entry point for automatic detection. It attempts to
+        This is the main entry point for automatic detection.  It attempts to
         identify the company first, then the specific account within that company.
 
         Args:
@@ -494,138 +514,3 @@ class ConfigManager:
                 return account
 
         raise StatementError(f"Unable to identify the company from the statement provided: {file_path}")
-
-
-# Module-level singleton for default configuration
-_default_config: ConfigManager | None = None
-
-
-def _get_default_config() -> ConfigManager:
-    """
-    Get or create the default ConfigManager singleton.
-
-    Returns:
-        The default ConfigManager instance.
-    """
-    global _default_config
-    if _default_config is None:
-        _default_config = ConfigManager()
-    return _default_config
-
-
-def _get_accounts() -> dict[str, Account]:
-    """Get accounts dict from default config."""
-    return _get_default_config().accounts
-
-
-def _get_statement_types() -> dict[str, StatementType]:
-    """Get statement types dict from default config."""
-    return _get_default_config().statement_types
-
-
-def _get_companies() -> dict[str, Company]:
-    """Get companies dict from default config."""
-    return _get_default_config().companies
-
-
-def _get_standard_fields() -> dict[str, StandardFields]:
-    """Get standard fields dict from default config."""
-    return _get_default_config().standard_fields
-
-
-# Backward-compatible module-level exports
-# Singletons are initialised lazily on first access via __getattr__ so that
-# importing this module does NOT trigger TOML file I/O immediately.
-_LAZY_SINGLETONS: dict[str, object] = {}
-
-_LAZY_FACTORIES: dict[str, object] = {
-    "config_accounts": _get_accounts,
-    "config_statement_types": _get_statement_types,
-    "config_companies": _get_companies,
-    "config_standard_fields": _get_standard_fields,
-}
-
-
-def __getattr__(name: str) -> object:
-    """Lazily initialise module-level config singletons on first access."""
-    if name in _LAZY_FACTORIES:
-        if name not in _LAZY_SINGLETONS:
-            _LAZY_SINGLETONS[name] = _LAZY_FACTORIES[name]()  # type: ignore[operator]
-        return _LAZY_SINGLETONS[name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def get_config_from_account(account_key: str, logs: pl.DataFrame, file_path: str, project_path: Path | None = None) -> Account:
-    """
-    Retrieve account configuration by key (backward-compatible function).
-
-    Args:
-        account_key: The account identifier.
-        logs: Polars DataFrame for logging operations.
-        file_path: Path to the PDF file being processed.
-        project_path: Optional project root directory path.
-
-    Returns:
-        The Account object.
-
-    Raises:
-        StatementError: If the account cannot be found.
-    """
-    config = ConfigManager(project_path) if project_path else _get_default_config()
-    return config.get_config_from_account(account_key, logs, file_path)
-
-
-def get_config_from_company(company_key: str, pdf: PDF, logs: pl.DataFrame, file_path: str, project_path: Path | None = None) -> Account:
-    """
-    Identify account from company by testing against PDF (backward-compatible function).
-
-    Args:
-        company_key: The company identifier.
-        pdf: The opened PDF object.
-        logs: Polars DataFrame for logging operations.
-        file_path: Path to the PDF file being processed.
-        project_path: Optional project root directory path.
-
-    Returns:
-        The matched Account object.
-
-    Raises:
-        StatementError: If no account can be matched.
-    """
-    config = ConfigManager(project_path) if project_path else _get_default_config()
-    return config.get_config_from_company(company_key, pdf, logs, file_path)
-
-
-def get_config_from_statement(pdf: PDF, file_path: str, logs: pl.DataFrame, project_path: Path | None = None) -> Account:
-    """
-    Identify company and account from PDF (backward-compatible function).
-
-    Args:
-        pdf: The opened PDF object.
-        file_path: Path to the PDF file being processed.
-        logs: Polars DataFrame for logging operations.
-        project_path: Optional project root directory path.
-
-    Returns:
-        The identified Account object.
-
-    Raises:
-        StatementError: If neither company nor account can be identified.
-    """
-    config = ConfigManager(project_path) if project_path else _get_default_config()
-    return config.get_config_from_statement(pdf, file_path, logs)
-
-
-def config_company_accounts(company_key: str, project_path: Path | None = None) -> list[Account]:
-    """
-    Get all accounts for a company (backward-compatible function).
-
-    Args:
-        company_key: The company identifier to filter by.
-        project_path: Optional project root directory path.
-
-    Returns:
-        List of Account objects for the specified company.
-    """
-    config = ConfigManager(project_path) if project_path else _get_default_config()
-    return config.get_accounts_for_company(company_key)

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -1,3 +1,19 @@
+"""
+paths — file-system layout constants and ProjectPaths factory.
+
+Module-level constants and the :class:`ProjectPaths` dataclass that derives
+every runtime path from a single project root directory.
+
+Constants:
+    BASE_CONFIG: Root of the default project's ``config/`` directory.
+    BASE_CONFIG_IMPORT: Default ``config/import/`` directory (bank-parsing TOMLs).
+    BASE_CONFIG_EXPORT: Default ``config/export/`` directory (export spec files).
+    BASE_CONFIG_REPORT: Default ``config/report/`` directory (report config).
+    BASE_CONFIG_USER: Default ``config/user/`` directory (user-specific config).
+    MODULES: The ``modules/`` directory inside the installed package.
+    DATA: The ``data/`` directory inside the installed package.
+"""
+
 from __future__ import annotations
 
 import shutil
@@ -15,24 +31,24 @@ from bank_statement_parser.modules.errors import (
 # Package-internal constants (never change — tied to the installed package)
 # ---------------------------------------------------------------------------
 
-# The shipped default TOML config files (inside the package, not the project).
-_BSP = Path(__file__).parent.parent
+# Anchor: the bank_statement_parser package root (src/bank_statement_parser/).
+_BSP: Path = Path(__file__).parent.parent
 
 # The default project root bundled with the package.
 _DEFAULT_PROJECT_ROOT: Path = _BSP.joinpath("project")
 
-# Root config directory bundled with the package.
-BASE_CONFIG = _DEFAULT_PROJECT_ROOT / "config"
+# Root of the default project's config/ directory.
+BASE_CONFIG: Path = _DEFAULT_PROJECT_ROOT.joinpath("config")
 
-# Config sub-directory constants — each maps to one of the four config subfolders.
-BASE_CONFIG_IMPORT = BASE_CONFIG / "import"  # Bank statement parsing TOML configs.
-BASE_CONFIG_EXPORT = BASE_CONFIG / "export"  # Export spec TOML files.
-BASE_CONFIG_REPORT = BASE_CONFIG / "report"  # Report config (reserved).
-BASE_CONFIG_USER = BASE_CONFIG / "user"  # User-specific config (e.g. anonymise.toml).
+# Sub-directory constants beneath BASE_CONFIG.
+BASE_CONFIG_IMPORT: Path = BASE_CONFIG.joinpath("import")
+BASE_CONFIG_EXPORT: Path = BASE_CONFIG.joinpath("export")
+BASE_CONFIG_REPORT: Path = BASE_CONFIG.joinpath("report")
+BASE_CONFIG_USER: Path = BASE_CONFIG.joinpath("user")
 
-# The modules directory (used by a few internal references).
-MODULES = _BSP.joinpath("modules")
-DATA = _BSP.joinpath("data")
+# The modules and data directories (used by a few internal references).
+MODULES: Path = _BSP.joinpath("modules")
+DATA: Path = _BSP.joinpath("data")
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +68,7 @@ class ProjectPaths:
           config/
             import/    ← TOML configs for parsing bank statements
             export/    ← export spec TOML files
-            report/    ← report config (reserved)
+            report/    ← report config
             user/      ← user-specific config (e.g. anonymise.toml)
           parquet/
           database/
@@ -64,6 +80,7 @@ class ProjectPaths:
               simple/  full/
           log/
             debug/
+
     Use :meth:`resolve` to obtain an instance rather than instantiating
     this class directly.
     """
@@ -71,60 +88,71 @@ class ProjectPaths:
     root: Path
 
     # ------------------------------------------------------------------
-    # Sub-directories
+    # Config sub-directories
     # ------------------------------------------------------------------
 
     @property
     def config_root(self) -> Path:
         """Root config directory (``config/``)."""
-        return self.root / "config"
+        return self.root.joinpath("config")
 
     @property
     def config_import(self) -> Path:
-        """Directory containing TOML configs for parsing bank statements (``config/import/``)."""
-        return self.config_root / "import"
+        """Directory containing import TOML config files (``config/import/``)."""
+        return self.config_root.joinpath("import")
 
     @property
     def config_export(self) -> Path:
-        """Directory containing export spec TOML files (``config/export/``)."""
-        return self.config_root / "export"
+        """Directory containing export spec files (``config/export/``)."""
+        return self.config_root.joinpath("export")
 
     @property
     def config_report(self) -> Path:
-        """Directory for report config files — reserved for future use (``config/report/``)."""
-        return self.config_root / "report"
+        """Directory containing report config files (``config/report/``)."""
+        return self.config_root.joinpath("report")
 
     @property
     def config_user(self) -> Path:
-        """Directory for user-specific config files, e.g. ``anonymise.toml`` (``config/user/``)."""
-        return self.config_root / "user"
+        """Directory containing user-specific config files (``config/user/``)."""
+        return self.config_root.joinpath("user")
+
+    # ------------------------------------------------------------------
+    # Data directories
+    # ------------------------------------------------------------------
 
     @property
     def parquet(self) -> Path:
         """Directory containing permanent and temporary Parquet files."""
-        return self.root / "parquet"
+        return self.root.joinpath("parquet")
 
     @property
     def database(self) -> Path:
         """Directory containing the SQLite database."""
-        return self.root / "database"
+        return self.root.joinpath("database")
+
+    # ------------------------------------------------------------------
+    # Export output directories
+    # ------------------------------------------------------------------
 
     @property
     def exports(self) -> Path:
-        """Root exports directory."""
-        return self.root / "export"
+        """Root exports directory (``export/``)."""
+        return self.root.joinpath("export")
 
     @property
     def csv(self) -> Path:
-        return self.exports / "csv"
+        """Directory for CSV export output (``export/csv/``)."""
+        return self.exports.joinpath("csv")
 
     @property
     def excel(self) -> Path:
-        return self.exports / "excel"
+        """Directory for Excel export output (``export/excel/``)."""
+        return self.exports.joinpath("excel")
 
     @property
     def json(self) -> Path:
-        return self.exports / "json"
+        """Directory for JSON export output (``export/json/``)."""
+        return self.exports.joinpath("json")
 
     @property
     def export_specs(self) -> Path:
@@ -135,50 +163,72 @@ class ProjectPaths:
         """Output directory for a named export spec (``export/<spec_stem>/``).
 
         Args:
-            spec_stem: The stem of the spec TOML file (filename without extension),
-                e.g. ``"quickbooks_3column"``.
+            spec_stem: The stem of the spec TOML file (filename without
+                extension), e.g. ``"quickbooks_3column"``.
 
         Returns:
-            A :class:`Path` pointing to ``export/<spec_stem>/`` inside the project.
+            A :class:`Path` pointing to ``export/<spec_stem>/`` inside the
+            project.
         """
-        return self.exports / spec_stem
+        return self.exports.joinpath(spec_stem)
+
+    # ------------------------------------------------------------------
+    # Reporting directories
+    # ------------------------------------------------------------------
 
     @property
     def reporting(self) -> Path:
-        """Root reporting directory."""
-        return self.root / "reporting"
+        """Root reporting directory (``reporting/``)."""
+        return self.root.joinpath("reporting")
 
     @property
     def reporting_data(self) -> Path:
-        """Directory containing reporting data feeds (CSV files)."""
-        return self.reporting / "data"
+        """Directory containing reporting data feeds (``reporting/data/``)."""
+        return self.reporting.joinpath("data")
 
     @property
     def reporting_data_simple(self) -> Path:
         """Reporting data directory for the simple (flat transactions) feed."""
-        return self.reporting_data / "simple"
+        return self.reporting_data.joinpath("simple")
 
     @property
     def reporting_data_full(self) -> Path:
         """Reporting data directory for the full (star-schema) feed."""
-        return self.reporting_data / "full"
+        return self.reporting_data.joinpath("full")
+
+    # ------------------------------------------------------------------
+    # Statements directory
+    # ------------------------------------------------------------------
 
     @property
     def statements(self) -> Path:
-        """Root directory for copied statement PDFs."""
-        return self.root / "statements"
+        """Root directory for copied statement PDFs (``statements/``)."""
+        return self.root.joinpath("statements")
+
+    # ------------------------------------------------------------------
+    # Log directories
+    # ------------------------------------------------------------------
 
     @property
     def logs(self) -> Path:
-        return self.root / "log"
+        """Root log directory (``log/``)."""
+        return self.root.joinpath("log")
 
     @property
     def log_debug(self) -> Path:
-        return self.logs / "debug"
+        """Directory for per-statement debug output (``log/debug/``)."""
+        return self.logs.joinpath("debug")
 
     def log_debug_dir(self, filename: str) -> Path:
-        """Returns the per-statement debug output directory inside log/debug/."""
-        return self.log_debug / filename
+        """Returns the per-statement debug output directory inside ``log/debug/``.
+
+        Args:
+            filename: The statement filename used to name the debug sub-directory.
+
+        Returns:
+            A :class:`Path` pointing to ``log/debug/<filename>/``.
+        """
+        return self.log_debug.joinpath(filename)
 
     # ------------------------------------------------------------------
     # Database file
@@ -186,13 +236,13 @@ class ProjectPaths:
 
     @property
     def project_db(self) -> Path:
-        """Path to the SQLite database file."""
-        return self.database / "project.db"
+        """Path to the SQLite database file (``database/project.db``)."""
+        return self.database.joinpath("project.db")
 
     @property
     def forex_config(self) -> Path:
-        """Path to the optional forex API config file."""
-        return self.config_import / "forex_api_config.toml"
+        """Path to the optional forex API config file (``config/import/forex_api_config.toml``)."""
+        return self.config_import.joinpath("forex_api_config.toml")
 
     # ------------------------------------------------------------------
     # Permanent Parquet files
@@ -200,23 +250,28 @@ class ProjectPaths:
 
     @property
     def cab(self) -> Path:
-        return self.parquet / "checks_and_balances.parquet"
+        """Permanent checks-and-balances Parquet file."""
+        return self.parquet.joinpath("checks_and_balances.parquet")
 
     @property
     def batch_heads(self) -> Path:
-        return self.parquet / "batch_heads.parquet"
+        """Permanent batch-heads Parquet file."""
+        return self.parquet.joinpath("batch_heads.parquet")
 
     @property
     def batch_lines(self) -> Path:
-        return self.parquet / "batch_lines.parquet"
+        """Permanent batch-lines Parquet file."""
+        return self.parquet.joinpath("batch_lines.parquet")
 
     @property
     def statement_heads(self) -> Path:
-        return self.parquet / "statement_heads.parquet"
+        """Permanent statement-heads Parquet file."""
+        return self.parquet.joinpath("statement_heads.parquet")
 
     @property
     def statement_lines(self) -> Path:
-        return self.parquet / "statement_lines.parquet"
+        """Permanent statement-lines Parquet file."""
+        return self.parquet.joinpath("statement_lines.parquet")
 
     # ------------------------------------------------------------------
     # Log files
@@ -224,47 +279,53 @@ class ProjectPaths:
 
     @property
     def log_error(self) -> Path:
-        return self.logs / "error.parquet"
+        """Error log Parquet file (``log/error.parquet``)."""
+        return self.logs.joinpath("error.parquet")
 
     @property
     def log_perf(self) -> Path:
-        return self.logs / "perf.parquet"
+        """Performance log Parquet file (``log/perf.parquet``)."""
+        return self.logs.joinpath("perf.parquet")
 
     # ------------------------------------------------------------------
     # Temporary Parquet files (written per-PDF during batch processing)
     # ------------------------------------------------------------------
 
-    def cab_temp(self, id: int, batch_id: str) -> Path:
-        """Temporary checks-and-balances file for PDF at index *id* in batch *batch_id*."""
-        return self.parquet / f"checks_and_balances_temp_{batch_id}_{id}.parquet"
+    def cab_temp(self, idx: int, batch_id: str) -> Path:
+        """Temporary checks-and-balances file for PDF at index *idx* in batch *batch_id*."""
+        return self.parquet.joinpath(f"checks_and_balances_temp_{batch_id}_{idx}.parquet")
 
-    def batch_lines_temp(self, id: int, batch_id: str) -> Path:
-        """Temporary batch-lines file for PDF at index *id* in batch *batch_id*."""
-        return self.parquet / f"batch_lines_temp_{batch_id}_{id}.parquet"
+    def batch_lines_temp(self, idx: int, batch_id: str) -> Path:
+        """Temporary batch-lines file for PDF at index *idx* in batch *batch_id*."""
+        return self.parquet.joinpath(f"batch_lines_temp_{batch_id}_{idx}.parquet")
 
-    def statement_heads_temp(self, id: int, batch_id: str) -> Path:
-        """Temporary statement-heads file for PDF at index *id* in batch *batch_id*."""
-        return self.parquet / f"statement_heads_temp_{batch_id}_{id}.parquet"
+    def statement_heads_temp(self, idx: int, batch_id: str) -> Path:
+        """Temporary statement-heads file for PDF at index *idx* in batch *batch_id*."""
+        return self.parquet.joinpath(f"statement_heads_temp_{batch_id}_{idx}.parquet")
 
-    def statement_lines_temp(self, id: int, batch_id: str) -> Path:
-        """Temporary statement-lines file for PDF at index *id* in batch *batch_id*."""
-        return self.parquet / f"statement_lines_temp_{batch_id}_{id}.parquet"
+    def statement_lines_temp(self, idx: int, batch_id: str) -> Path:
+        """Temporary statement-lines file for PDF at index *idx* in batch *batch_id*."""
+        return self.parquet.joinpath(f"statement_lines_temp_{batch_id}_{idx}.parquet")
 
     # ------------------------------------------------------------------
     # Filename stems (no directory, no extension)
     # ------------------------------------------------------------------
 
-    def cab_temp_stem(self, id: int, batch_id: str) -> str:
-        return f"checks_and_balances_temp_{batch_id}_{id}"
+    def cab_temp_stem(self, idx: int, batch_id: str) -> str:
+        """Stem of the temporary checks-and-balances file for PDF *idx* in batch *batch_id*."""
+        return f"checks_and_balances_temp_{batch_id}_{idx}"
 
-    def batch_lines_temp_stem(self, id: int, batch_id: str) -> str:
-        return f"batch_lines_temp_{batch_id}_{id}"
+    def batch_lines_temp_stem(self, idx: int, batch_id: str) -> str:
+        """Stem of the temporary batch-lines file for PDF *idx* in batch *batch_id*."""
+        return f"batch_lines_temp_{batch_id}_{idx}"
 
-    def statement_heads_temp_stem(self, id: int, batch_id: str) -> str:
-        return f"statement_heads_temp_{batch_id}_{id}"
+    def statement_heads_temp_stem(self, idx: int, batch_id: str) -> str:
+        """Stem of the temporary statement-heads file for PDF *idx* in batch *batch_id*."""
+        return f"statement_heads_temp_{batch_id}_{idx}"
 
-    def statement_lines_temp_stem(self, id: int, batch_id: str) -> str:
-        return f"statement_lines_temp_{batch_id}_{id}"
+    def statement_lines_temp_stem(self, idx: int, batch_id: str) -> str:
+        """Stem of the temporary statement-lines file for PDF *idx* in batch *batch_id*."""
+        return f"statement_lines_temp_{batch_id}_{idx}"
 
     # ------------------------------------------------------------------
     # Factory
@@ -299,12 +360,23 @@ class ProjectPaths:
     # ------------------------------------------------------------------
 
     def require_subdir_for_read(self, subdir: Path) -> None:
-        """Raise ProjectSubFolderNotFound if *subdir* does not exist (read guard)."""
+        """Raise ProjectSubFolderNotFound if *subdir* does not exist (read guard).
+
+        Args:
+            subdir: The sub-directory path to check.
+
+        Raises:
+            ProjectSubFolderNotFound: If *subdir* is not a directory.
+        """
         if not subdir.is_dir():
             raise ProjectSubFolderNotFound(subdir)
 
     def ensure_subdir_for_write(self, subdir: Path) -> None:
-        """Create *subdir* (and any parents) if it does not already exist (write guard)."""
+        """Create *subdir* (and any parents) if it does not already exist (write guard).
+
+        Args:
+            subdir: The sub-directory path to create.
+        """
         subdir.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------
@@ -377,7 +449,7 @@ def copy_project_folders(destination: Path) -> list[Path]:
     for src_dir in sorted(_DEFAULT_PROJECT_ROOT.rglob("*")):
         if src_dir.is_dir():
             relative = src_dir.relative_to(_DEFAULT_PROJECT_ROOT)
-            dest_dir = destination / relative
+            dest_dir = destination.joinpath(relative)
             dest_dir.mkdir(parents=True, exist_ok=True)
             created.append(dest_dir)
 
@@ -489,8 +561,9 @@ def _create_project_db(paths: ProjectPaths) -> None:
 
 def _scaffold_new_project(paths: ProjectPaths) -> None:
     """
-    Create all project sub-directories, copy default TOML configs, and
-    initialise a new empty SQLite database.
+    Create all project sub-directories, copy default TOML configs, copy default
+    export specs, copy default report configs, and initialise a new empty SQLite
+    database.
 
     This is an internal helper called only by
     :func:`validate_or_initialise_project`.
@@ -502,15 +575,33 @@ def _scaffold_new_project(paths: ProjectPaths) -> None:
     # 1. Create the full directory tree.
     paths.ensure_dirs()
 
-    # 2. Copy default TOML config files (including any company subfolders).
+    # 2. Copy default import TOML config files (including company subfolders).
     for src in BASE_CONFIG_IMPORT.rglob("*.toml"):
         relative = src.relative_to(BASE_CONFIG_IMPORT)
-        dst = paths.config_import / relative
+        dst = paths.config_import.joinpath(relative)
         dst.parent.mkdir(parents=True, exist_ok=True)
         if not dst.exists():
             shutil.copy2(src, dst)
 
-    # 3. Create the SQLite database with the full schema.
+    # 3. Copy export spec files (.toml and .sql) from the default config/export/.
+    for src in BASE_CONFIG_EXPORT.rglob("*"):
+        if src.is_file():
+            relative = src.relative_to(BASE_CONFIG_EXPORT)
+            dst = paths.config_export.joinpath(relative)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if not dst.exists():
+                shutil.copy2(src, dst)
+
+    # 4. Copy report config files from the default config/report/.
+    for src in BASE_CONFIG_REPORT.rglob("*"):
+        if src.is_file():
+            relative = src.relative_to(BASE_CONFIG_REPORT)
+            dst = paths.config_report.joinpath(relative)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if not dst.exists():
+                shutil.copy2(src, dst)
+
+    # 5. Create the SQLite database with the full schema.
     #    Import here to avoid a circular dependency at module level
     #    (database.py → paths.py; paths.py must not import database.py at top).
     from bank_statement_parser.data.create_project_db import main as create_db  # noqa: PLC0415

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -28,13 +28,8 @@ from uuid import uuid4
 
 import polars as pl
 
-import bank_statement_parser.modules.config as _config_module
 import bank_statement_parser.modules.parquet as pq
-from bank_statement_parser.modules.config import (
-    get_config_from_account,
-    get_config_from_company,
-    get_config_from_statement,
-)
+from bank_statement_parser.modules.import_config import ImportConfigManager
 from bank_statement_parser.modules.data import (
     Account,
     Failure,
@@ -472,15 +467,9 @@ class Statement:
                     )
 
         if self.statement_type:
-            # Resolve config_standard_fields at call time via the module reference so that:
-            #   a) the lazy __getattr__ singleton is not frozen at import time, and
-            #   b) a custom project_path on this Statement is respected.
-            if self.project_path:
-                from bank_statement_parser.modules.config import ConfigManager
-
-                std_fields: dict[str, StandardFields] = ConfigManager(self.project_path).standard_fields
-            else:
-                std_fields = _config_module.config_standard_fields  # type: ignore[assignment]
+            # Resolve standard_fields via ImportConfigManager so that a custom
+            # project_path on this Statement is always respected.
+            std_fields: dict[str, StandardFields] = ImportConfigManager(self.project_path).standard_fields
             # Apply standard field transformations based on statement type
             results = results.pipe(
                 get_standard_fields,
@@ -508,13 +497,15 @@ class Statement:
             return None
         if self.account_key:
             # Use explicit account key if provided
-            config = get_config_from_account(self.account_key, self.logs, self.file_absolute, self.project_path)
+            config = ImportConfigManager(self.project_path).get_config_from_account(self.account_key, self.logs, self.file_absolute)
         elif self.company_key:
             # Use explicit company key if provided
-            config = get_config_from_company(self.company_key, self.pdf, self.logs, self.file_absolute, self.project_path)
+            config = ImportConfigManager(self.project_path).get_config_from_company(
+                self.company_key, self.pdf, self.logs, self.file_absolute
+            )
         else:
             # Attempt auto-detection from statement content
-            config = get_config_from_statement(self.pdf, self.file_absolute, self.logs, self.project_path)
+            config = ImportConfigManager(self.project_path).get_config_from_statement(self.pdf, self.file_absolute, self.logs)
         return deepcopy(config) if config else None  # we return a deepcopy in case we need to make statement-specific modifications
 
     def cleanup(self):

--- a/src/bank_statement_parser/testing.py
+++ b/src/bank_statement_parser/testing.py
@@ -257,7 +257,7 @@ class TestHarness:
         """
         if not self._ready or self._project_path is None:
             raise RuntimeError("TestHarness.setup() must be called before accessing db_path.")
-        return ProjectPaths(root=self._project_path).project_db
+        return ProjectPaths.resolve(self._project_path).project_db
 
     @property
     def project_path(self) -> Path:

--- a/tests/test_export_spec.py
+++ b/tests/test_export_spec.py
@@ -35,16 +35,16 @@ import pytest
 
 from bank_statement_parser.modules.errors import ConfigError
 from bank_statement_parser.modules.export_spec import ExportSpec, _load_spec, export_spec
-from bank_statement_parser.modules.paths import ProjectPaths
+from bank_statement_parser.modules.paths import BASE_CONFIG_EXPORT, ProjectPaths
 
 # ---------------------------------------------------------------------------
 # Helpers / constants
 # ---------------------------------------------------------------------------
 
 # Paths to the two shipped QuickBooks spec files
-_SPECS_DIR = Path(__file__).parent.parent / "src" / "bank_statement_parser" / "project" / "config" / "export"
-_SPEC_3COL = _SPECS_DIR / "quickbooks_3column.toml"
-_SPEC_4COL = _SPECS_DIR / "quickbooks_4column.toml"
+_SPECS_DIR = BASE_CONFIG_EXPORT
+_SPEC_3COL = _SPECS_DIR.joinpath("quickbooks_3column.toml")
+_SPEC_4COL = _SPECS_DIR.joinpath("quickbooks_4column.toml")
 
 # One well-known id_account present in the good_project test data
 _ACCOUNT_KEY = "HSBC_UK_CUR_12345678"


### PR DESCRIPTION
## Summary

- **Rename `config.py` → `import_config.py`**: `ConfigManager` → `ImportConfigManager`, `copy_default_config` → `copy_default_import_config`. Removes all backward-compat wrappers and lazy singletons; callers now use `ImportConfigManager` directly.
- **Fix `copy_default_import_config` rglob bug**: was using `glob` so company-subdirectory TOMLs were silently skipped; switched to `rglob` with subdirectory structure preserved in the destination.
- **Standardise `paths.py` Path construction**: all `/` operator usage replaced with `.joinpath()`; each path resolved from its direct parent property.
- **Remove redundant `export_config` alias** and its duplicate in `ensure_dirs()`; `export_specs` and `export_specs_output` are retained (used by `export_spec.py`).
- **Wire `BASE_CONFIG_REPORT` into `_scaffold_new_project`** so report config files are copied to new projects.
- **Housekeeping in `paths.py`**: rename `id` → `idx` in temp-file methods, add missing docstrings and type annotations throughout.
- **Fix `data/` `__main__` guards** to use `ProjectPaths.resolve().project_db` instead of hardcoded relative paths.
- **Update `testing.py`** to use `ProjectPaths.resolve()` instead of `ProjectPaths(root=...)`.
- **Update `tests/test_export_spec.py`** to import `BASE_CONFIG_EXPORT` from `paths` instead of a hardcoded 6-segment path.
- **Regenerate `docs/reference/python-api.md`** after public API rename.

## Test results

202/202 tests passing · ruff lint + format clean

## Breaking changes

- `ConfigManager` removed — use `ImportConfigManager`
- `copy_default_config` removed — use `copy_default_import_config`
- `ProjectPaths.export_config` property removed — use `ProjectPaths.config_export` or `ProjectPaths.export_specs`