### PR TITLE
feat: rename export type simple/full → single/multi, human-readable timestamps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Python library for parsing bank statement PDFs, extracting structured transactio
 
 ## Technology Stack
 
-- **Python**: 3.14+ · **Package Manager**: uv · **Build Backend**: uv_build
+- **Python**: 3.14+ (`target-version = "py314"`) · **Package Manager**: uv · **Build Backend**: uv_build
 - **Data**: Polars ≥ 1.36.1 (LazyFrames preferred) · xlsxwriter
 - **PDF**: pdfplumber ≥ 0.11.9 · pikepdf ≥ 10.3.0
 - **Config**: dacite (TOML → dataclasses)
@@ -35,8 +35,8 @@ ruff format .                        # format
 
 ## Test Fixtures
 
-- `tests/test_datamart.py` — session-scoped `_db_lifecycle` fixture creates `tests/test_project.db`, populates it via `generate_mock_data()`, builds the mart, runs tests, then deletes the DB. Self-contained.
-- `tests/conftest.py` — session-scoped `good_project` and `bad_project` fixtures process real PDFs from `tests/pdfs/good/` and `tests/pdfs/bad/` into temporary project directories. Torn down via `shutil.rmtree` after the session.
+- `tests/test_datamart.py` — session-scoped `_db_lifecycle` fixture (`autouse=True`) creates `tests/test_project.db`, populates it via `generate_mock_data()`, builds the mart, runs tests, then deletes the DB. A separate `scope="module"` fixture `conn` provides a shared `sqlite3.Connection`. Self-contained.
+- `tests/conftest.py` — session-scoped `good_project` and `bad_project` fixtures (`autouse=False`) process real PDFs from the bundled `test_data/pdfs/good/` and `test_data/pdfs/bad/` directories into temporary project directories. Each fixture yields a `ProjectContext` dataclass (`project_path`, `batch`, `pdfs`). Torn down via `shutil.rmtree` in a `try/finally` after the session.
 
 ## Architecture
 
@@ -50,7 +50,7 @@ PDF files → StatementBatch (statements.py) → Statement (statements.py)
   → DimTime / DimAccount / DimStatement / FactTransaction / FactBalance
 ```
 
-`StatementBatch` uses `asyncio` + `ProcessPoolExecutor` for parallel mode (`turbo=True`). The worker is a module-level function to avoid pickling issues.
+`StatementBatch` uses `asyncio` + `ProcessPoolExecutor` for parallel mode (`turbo=True`). The worker is a module-level function (`process_pdf_statement`) — not a bound method — so it can be pickled for child processes. `ProcessPoolExecutor` is created with the `forkserver` multiprocessing context. Invoked via `asyncio.run(self.process_turbo(), debug=False)`.
 
 ## Code Style
 
@@ -65,7 +65,21 @@ import polars as pl
 from bank_statement_parser.modules.config import ConfigManager
 ```
 
+Deferred imports (inside function bodies, to break circular dependencies) are annotated with `# noqa: PLC0415`. This is the only accepted reason for a non-top-level import.
+
+`from __future__ import annotations` is used in exactly five files (`paths.py`, `anonymise.py`, `parquet.py`, `cli.py`, `_anonymise_shared.py`) where forward references are needed. It is **not** a project-wide convention. Elsewhere, forward references use quoted strings (e.g. `"ProjectPaths"`, `"Success | Review | Failure"`).
+
 ### Type Hints — required on all parameters and return values. Use `str | None` (not `Optional[str]`). Use `pl.LazyFrame` / `pl.DataFrame` for Polars types.
+
+**Exception**: `data.py` configuration dataclasses (loaded by `dacite` from TOML) use `Optional[T]` throughout because `dacite` requires it for optional TOML keys. Do not change these to `T | None`; the `Optional` import in `data.py` is intentional.
+
+`Literal[...]` is used for fields and parameters whose values are drawn from a fixed set of strings (e.g. `Literal["SUCCESS", "REVIEW", "FAILURE"]` on `PdfResult.result`; `Literal["config", "data", "other"]` on `Failure.error_type`). Use it whenever a string parameter or field has a closed set of valid values.
+
+There are no `TypeAlias`, `Protocol`, `ABC`, or `@abstractmethod` uses in this codebase. Do not introduce them.
+
+### `type: ignore` — always supply the specific mypy error code: `# type: ignore[union-attr]`, `# type: ignore[arg-type]`, etc. A bare `# type: ignore` (without a code) is not acceptable.
+
+### `# noqa` — always supply the specific ruff rule code. Active codes in use: `PLC0415` (deferred import), `S608` (SQL string), `ARG001` (unused argument), `F401` (re-export). A bare `# noqa` is not acceptable.
 
 ### Naming
 
@@ -73,9 +87,11 @@ from bank_statement_parser.modules.config import ConfigManager
 |---|---|---|
 | Classes | PascalCase | `StatementBatch` |
 | Functions / methods | snake_case | `process_statement` |
-| Constants / DDL | SCREAMING_SNAKE_CASE | `_DDL_FACT_TRANSACTION` |
+| Module-level constants / DDL | SCREAMING_SNAKE_CASE | `_DDL_FACT_TRANSACTION` |
 | Private | leading underscore | `_internal_method` |
 | Files / modules | snake_case | `statement_functions.py` |
+
+Private constants use a leading underscore: `_ALLOWED_TABLES`. Public shared constants do not: `FLOAT_TOL`.
 
 ### Classes — use `__slots__` on every class. Regular classes declare a tuple; dataclasses use `slots=True`. Subclasses declare only their own additional slots.
 
@@ -90,9 +106,40 @@ class Account:
     company_key: str
 ```
 
-### Docstrings — Google-style (Args / Returns / Raises) on all public functions and methods. Every module starts with a module-level docstring. Dataclass fields use inline comments.
+**Class-level constants** (lookup tables, whitelists) that are shared across all instances are declared as plain class-body attributes — they are **not** listed in `__slots__` and are not instance variables. Example from `housekeeping.py`:
 
-### `__all__` — every `__init__.py` defines `__all__` as a list of strings, grouped with comment headers.
+```python
+class Housekeeping:
+    FK_RELATIONSHIPS = [...]          # class variable, not in __slots__
+    _ALLOWED_TABLES: frozenset[str] = frozenset([...])
+```
+
+Use `frozenset[str]` for any identifier or name whitelist used in membership tests (SQL injection guards, column name validation, etc.).
+
+### Decorators — `@property`, `@classmethod`, `@staticmethod`
+
+- `@property`: used for computed attributes that must be validated before access (e.g. `ProjectPaths` exposes 26 `@property` accessors; `TestHarness` guards `db_path` with a readiness check).
+- `@classmethod`: used for alternative constructors (e.g. `ProjectPaths.resolve`).
+- `@staticmethod`: used for pure helper functions attached to a class by namespace (e.g. `Housekeeping._validate_identifier`).
+
+### Context Managers
+
+- Use `@contextmanager` (from `contextlib`) with `try/finally` for function-based context managers.
+- Classes that own a resource lifecycle implement `__enter__` / `__exit__`. `__enter__` returns `self` (or the result of a setup call); `__exit__` accepts `*args: object` and always cleans up regardless of exceptions.
+
+```python
+def __enter__(self) -> "TestHarness":
+    return self.setup()
+
+def __exit__(self, *args: object) -> None:
+    self.teardown()
+```
+
+- The codebase has **no generator functions** (bare `yield` outside a `@contextmanager`).
+
+### Docstrings — Google-style (Args / Returns / Raises) on all public functions and methods. Every module starts with a module-level docstring. Dataclass fields use inline comments prefixed with `# [ACTIVE]` or `# [STUB]` where applicable.
+
+### `__all__` — every `__init__.py` defines `__all__` as a list of strings, grouped with comment headers. Sub-packages are re-exported with a namespace alias where appropriate (e.g. `import bank_statement_parser.modules.reports_db as db`).
 
 ### Polars — prefer `LazyFrame`; `.collect()` only at the boundary. Use `.pipe()` for pipelines. `vstack(in_place=True)` for row accumulation; `hstack(in_place=True)` for column mutation. No Python-level row iteration.
 
@@ -101,6 +148,10 @@ class Account:
 ### Paths — `Path(__file__).parent` chains for internal paths. Always `mkdir(parents=True, exist_ok=True)`. Pass `str(path)` to libraries that reject `Path`.
 
 ### Logging — no `logging` module. User output via `print()`. `pl.Config` display blocks only in `if __name__ == "__main__"` guards.
+
+### Warnings — use `warnings.warn` for non-fatal issues:
+- `DeprecationWarning` for deprecated API aliases (e.g. deprecated `filetype='both'` parameter).
+- `UserWarning` for non-fatal operational problems (e.g. FX rate lookup failures in `forex.py`).
 
 ### Error Handling — raise from the custom hierarchy in `errors.py`:
 
@@ -112,7 +163,27 @@ Let exceptions propagate unless the caller can meaningfully recover. `assert` is
 
 ### SQL — DDL stored as `_DDL_*` module-level constants. Queries use triple-quoted f-strings. `INSERT OR REPLACE … executemany`. Dynamic identifiers guarded by `frozenset` whitelist + `_validate_identifier()`.
 
+`sqlite3` date/datetime adapters are registered at module level in `database.py` to emit ISO-format strings and avoid Python 3.12+ deprecation warnings:
+
+```python
+sqlite3.register_adapter(date, lambda d: d.isoformat())
+sqlite3.register_adapter(datetime, lambda dt: dt.isoformat())
+```
+
 ### Configuration — TOML files in `project/config/` (user overrides) or shipped `base_config/` defaults. Loaded via `ConfigManager` + `dacite`.
+
+## Testing Conventions
+
+- All fixtures are `scope="session"` unless noted. `autouse=True` only for lifecycle fixtures that every test in the file depends on (e.g. `_db_lifecycle`).
+- Fixtures yield, with teardown in a `try/finally` block.
+- The `conftest.py` fixtures yield a `ProjectContext` dataclass — never a raw path.
+- All test methods live inside named classes. No standalone test functions at module level.
+- Each test method has a single-sentence docstring.
+- `@pytest.mark.parametrize` is used only in `test_cli.py` and `test_docs.py`. Integration and datamart tests do not use it.
+- `FLOAT_TOL = 0.005` is the module-level constant for monetary float comparisons: `abs(a - b) < FLOAT_TOL`.
+- Use `_scalar(conn, sql, params=())` (defined in `test_datamart.py`) to reduce SQL boilerplate in datamart tests.
+- Use `dataclasses.replace()` to produce mutated copies of frozen dataclasses in tests — do not bypass `frozen=True` with `object.__setattr__`.
+- Use `warnings.catch_warnings(record=True)` to assert that deprecation or user warnings are emitted.
 
 ## File Organisation
 
@@ -122,6 +193,7 @@ src/bank_statement_parser/
 ├── __main__.py                 # Entry point
 ├── cli.py                      # CLI subcommands (bsp process, bsp anonymise)
 ├── dev.py                      # Developer scratch — do NOT use as reference
+├── testing.py                  # TestHarness — for dependent projects only
 ├── data/
 │   ├── build_datamart.py       # build_datamart() — star-schema rebuild
 │   ├── build_datamart.sql      # SQL equivalent (MUST stay in sync with .py)
@@ -148,7 +220,9 @@ src/bank_statement_parser/
 tests/
 ├── conftest.py                 # Session-scoped good_project / bad_project fixtures
 ├── test_datamart.py            # Star-schema mart tests (mock data, self-contained DB)
-└── test_statements.py          # Integration tests (real PDFs, reports, exports)
+├── test_statements.py          # Integration tests (real PDFs, reports, exports)
+├── test_cli.py                 # CLI subcommand tests (uses parametrize)
+└── test_docs.py                # Documentation/API surface tests (uses parametrize)
 ```
 
 ## Development Notes
@@ -158,3 +232,5 @@ tests/
 - **`build_datamart.py` and `build_datamart.sql` must stay in sync.** The `.py` file is authoritative at runtime; the `.sql` file is for direct `sqlite3` CLI use.
 - `build_datamart()` runs a full star-schema rebuild on every `update_db()` call.
 - `mock_project_data.py` is for test seeding only — never import it in production paths.
+- `testing.py` exposes `TestHarness` for use by **dependent external projects** (e.g. integration test suites that need a live bsp database). It is not used by bsp's own test suite directly.
+- There is no `py.typed` marker file. PEP 561 typed-package compliance is not established; do not add `py.typed` without also auditing all `type: ignore` suppressions and ensuring mypy passes cleanly.

--- a/docs/guides/exports.md
+++ b/docs/guides/exports.md
@@ -42,14 +42,28 @@ bsp process --pdfs ~/statements --no-export
 #### `export_csv()`
 
 ```python
-export_csv(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+export_csv(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
 ```
 
 Write report data to CSV files in *folder*.
 
 Each table is written as a separate ``.csv`` file named after its logical
-table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
-``account.csv``, etc. for ``type="full"``).
+table name (e.g. ``transactions.csv``, or ``statement_dimension.csv``,
+``account_dimension.csv``, etc. for ``type="multi"``).
+
+When *filename_timestamp* is ``True``:
+
+- ``type="single"``: the timestamp is appended to the filename, e.g.
+``transactions_20250331143022.csv``.
+- ``type="multi"``: files are written into a ``multi_20250331143022/``
+sub-folder inside *folder* with their original names.
+
+When *filename_timestamp* is ``False``:
+
+- ``type="single"``: files are written directly to *folder* with their
+original names, e.g. ``transactions.csv``.
+- ``type="multi"``: files are written into a ``multi/`` sub-folder inside
+*folder* with their original names.
 
 
 **Args:**
@@ -57,25 +71,40 @@ table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
 - `folder` — Directory to write CSV files into.  When ``None`` the project's
   ``export/csv/`` directory (resolved via *project_path*) is used and
   created automatically if absent.
-- `type` — Export preset — ``"simple"`` (flat transactions table) or
-  ``"full"`` (separate star-schema tables for loading into a
-  database).  Defaults to ``"simple"``.
+- `type` — Export preset — ``"single"`` (flat transactions table) or
+  ``"multi"`` (separate star-schema tables for loading into a
+  database).  Defaults to ``"single"``.
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+- `batch_id` — Optional batch identifier to filter report data to a single
+  batch.  When ``None`` all rows are exported.
+- `filename_timestamp` — When ``True``, append a human-readable timestamp
+  (``yyyymmddHHMMSS``) to the filename (single) or create a
+  timestamped sub-folder (multi).  Defaults to ``False``.
 
 #### `export_excel()`
 
 ```python
-export_excel(path: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+export_excel(path: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
 ```
 
 Write report data to an Excel workbook at *path*.
 
-Each table is written as a separate worksheet.  For ``type="simple"`` a
-single ``transactions_table`` sheet is written; for ``type="full"`` six
-sheets are written (``statement``, ``account``, ``calendar``,
-``transactions``, ``balances``, ``gaps``).
+Each table is written as a separate worksheet.  For ``type="single"`` a
+single ``transactions`` sheet is written; for ``type="multi"`` six sheets
+are written (``statement_dimension``, ``account_dimension``,
+``calendar_dimension``, ``transaction_measures``,
+``daily_account_balances``, ``missing_statement_report``).
+
+Filename conventions:
+
+- ``type="single"``, no timestamp: ``transactions.xlsx``
+- ``type="single"``, with timestamp: ``transactions_20250331143022.xlsx``
+- ``type="multi"``, no timestamp: ``transactions_multi.xlsx``
+- ``type="multi"``, with timestamp: ``transactions_multi_20250331143022.xlsx``
+
+Worksheet names are never modified by the timestamp or type logic.
 
 
 **Args:**
@@ -83,25 +112,44 @@ sheets are written (``statement``, ``account``, ``calendar``,
 - `path` — Full file path for the output ``.xlsx`` workbook.  When ``None``
   the file is written to ``export/excel/transactions.xlsx`` inside the
   project directory resolved via *project_path*.
-- `type` — Export preset — ``"simple"`` (flat transactions table) or
-  ``"full"`` (separate star-schema sheets for loading into a
-  database).  Defaults to ``"simple"``.
+- `type` — Export preset — ``"single"`` (flat transactions table) or
+  ``"multi"`` (separate star-schema sheets for loading into a
+  database).  Defaults to ``"single"``.
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+- `batch_id` — Optional batch identifier to filter report data to a single
+  batch.  When ``None`` all rows are exported.
+- `filename_timestamp` — When ``True``, append a human-readable timestamp
+  (``yyyymmddHHMMSS``) to the workbook filename.  Worksheet names
+  are unaffected.  Defaults to ``False``.
 
 #### `export_json()`
 
 ```python
-export_json(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+export_json(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
 ```
 
 Write report data to JSON files in *folder*.
 
 Each table is written as a separate ``.json`` file containing a JSON array
 of row objects, named after its logical table name (e.g.
-``transactions_table.json``, or ``statement.json``, ``account.json``, etc.
-for ``type="full"``).
+``transactions.json``, or ``statement_dimension.json``,
+``account_dimension.json``, etc. for ``type="multi"``).
+
+When *filename_timestamp* is ``True``:
+
+- ``type="single"``: the timestamp is appended to the filename, e.g.
+``transactions_20250331143022.json``.
+- ``type="multi"``: files are written into a ``multi_20250331143022/``
+sub-folder inside *folder* with their original names.
+
+When *filename_timestamp* is ``False``:
+
+- ``type="single"``: files are written directly to *folder* with their
+original names, e.g. ``transactions.json``.
+- ``type="multi"``: files are written into a ``multi/`` sub-folder inside
+*folder* with their original names.
 
 
 **Args:**
@@ -109,12 +157,17 @@ for ``type="full"``).
 - `folder` — Directory to write JSON files into.  When ``None`` the
   project's ``export/json/`` directory (resolved via *project_path*)
   is used and created automatically if absent.
-- `type` — Export preset — ``"simple"`` (flat transactions table) or
-  ``"full"`` (separate star-schema tables for loading into a
-  database).  Defaults to ``"simple"``.
+- `type` — Export preset — ``"single"`` (flat transactions table) or
+  ``"multi"`` (separate star-schema tables for loading into a
+  database).  Defaults to ``"single"``.
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+- `batch_id` — Optional batch identifier to filter report data to a single
+  batch.  When ``None`` all rows are exported.
+- `filename_timestamp` — When ``True``, append a human-readable timestamp
+  (``yyyymmddHHMMSS``) to the filename (single) or create a
+  timestamped sub-folder (multi).  Defaults to ``False``.
 
 #### `export_reporting_data()`
 
@@ -124,9 +177,10 @@ export_reporting_data(project_path: Path | None = None) -> None
 
 Write CSV reporting feeds to the project's ``reporting/data/`` sub-directories.
 
-Calls :func:`export_csv` twice — once with ``type="simple"`` writing to
-``reporting/data/simple/`` and once with ``type="full"`` writing to
-``reporting/data/full/``.  Both directories are created automatically if
+Calls :func:`export_csv` twice — once with ``type="single"`` writing to
+``reporting/data/single/`` and once with ``type="multi"`` writing to
+``reporting/data/multi/`` (created as a sub-folder of ``reporting/data/``
+by the multi-export logic).  Both directories are created automatically if
 absent.
 
 This produces a stable set of CSV files that external reporting tools
@@ -148,13 +202,13 @@ to know about the full export machinery.
 
     bsp.db.export_reporting_data(project_path=Path("/my/project"))
     # Writes:
-    #   /my/project/reporting/data/simple/transactions_table.csv
-    #   /my/project/reporting/data/full/statement.csv
-    #   /my/project/reporting/data/full/account.csv
-    #   /my/project/reporting/data/full/calendar.csv
-    #   /my/project/reporting/data/full/transactions.csv
-    #   /my/project/reporting/data/full/balances.csv
-    #   /my/project/reporting/data/full/gaps.csv
+    #   /my/project/reporting/data/single/transactions.csv
+    #   /my/project/reporting/data/multi/statement_dimension.csv
+    #   /my/project/reporting/data/multi/account_dimension.csv
+    #   /my/project/reporting/data/multi/calendar_dimension.csv
+    #   /my/project/reporting/data/multi/transaction_measures.csv
+    #   /my/project/reporting/data/multi/daily_account_balances.csv
+    #   /my/project/reporting/data/multi/missing_statement_report.csv
 ```
 
 ### Usage examples

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,7 @@ bsp anonymise PATH [--folder] [--pattern GLOB] [--output OUT_FILE] [--output-dir
 Discover PDF bank statements, extract transaction data, persist results to Parquet and/or SQLite, copy source PDFs into the project tree, and export reports as Excel, CSV, JSON, and/or CSV reporting feeds. A project folder is created automatically if it does not exist.
 
 ```
-bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,json,all,reporting}] [--export-type {full,simple}] [--no-export] [--no-copy]
+bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--company KEY] [--account KEY] [--data {parquet,database,both}] [--export-format {excel,csv,json,all,reporting}] [--export-type {single,multi}] [--no-export] [--no-copy] [--batch-id ID] [--filename-timestamp]
 ```
 
 ### Options
@@ -70,9 +70,11 @@ bsp process [--project PATH] [--pdfs PATH] [--pattern GLOB] [--no-turbo] [--comp
 | `--account` | auto-detect | Account key for config lookup (default: auto-detect from PDF). |
 | `--data` | `both` | Persistence target for update_data() (default: 'both'). Choices: `parquet`, `database`, `both`. |
 | `--export-format` | `all` | Export file format (default: 'all'). Choices: `excel`, `csv`, `json`, `all`, `reporting`. |
-| `--export-type` | `simple` | Export preset. 'simple' (default) exports a single flat transactions table. 'full' exports separate star-schema tables (accounts, calendar, statements, transactions, balances, gaps) intended for loading into an external database. Choices: `full`, `simple`. |
+| `--export-type` | `single` | Export preset. 'single' (default) exports a single flat transactions table. 'multi' exports separate star-schema tables (accounts, calendar, statements, transactions, balances, gaps) intended for loading into an external database. Choices: `single`, `multi`. |
 | `--no-export` | off | Skip the export step entirely. |
 | `--no-copy` | off | Skip copying source PDFs into the project statements/ directory. |
+| `--batch-id` | auto-detect | Filter exports to a single batch identifier (default: export all batches). |
+| `--filename-timestamp` | off | Append a human-readable timestamp (yyyymmddHHMMSS) to exported filenames. For multi exports (CSV/JSON) a timestamped sub-folder is created instead. |
 
 ## Examples
 

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -293,14 +293,28 @@ Available in `bsp.db`:
 #### `export_csv()`
 
 ```python
-export_csv(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+export_csv(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
 ```
 
 Write report data to CSV files in *folder*.
 
 Each table is written as a separate ``.csv`` file named after its logical
-table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
-``account.csv``, etc. for ``type="full"``).
+table name (e.g. ``transactions.csv``, or ``statement_dimension.csv``,
+``account_dimension.csv``, etc. for ``type="multi"``).
+
+When *filename_timestamp* is ``True``:
+
+- ``type="single"``: the timestamp is appended to the filename, e.g.
+``transactions_20250331143022.csv``.
+- ``type="multi"``: files are written into a ``multi_20250331143022/``
+sub-folder inside *folder* with their original names.
+
+When *filename_timestamp* is ``False``:
+
+- ``type="single"``: files are written directly to *folder* with their
+original names, e.g. ``transactions.csv``.
+- ``type="multi"``: files are written into a ``multi/`` sub-folder inside
+*folder* with their original names.
 
 
 **Args:**
@@ -308,25 +322,40 @@ table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
 - `folder` — Directory to write CSV files into.  When ``None`` the project's
   ``export/csv/`` directory (resolved via *project_path*) is used and
   created automatically if absent.
-- `type` — Export preset — ``"simple"`` (flat transactions table) or
-  ``"full"`` (separate star-schema tables for loading into a
-  database).  Defaults to ``"simple"``.
+- `type` — Export preset — ``"single"`` (flat transactions table) or
+  ``"multi"`` (separate star-schema tables for loading into a
+  database).  Defaults to ``"single"``.
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+- `batch_id` — Optional batch identifier to filter report data to a single
+  batch.  When ``None`` all rows are exported.
+- `filename_timestamp` — When ``True``, append a human-readable timestamp
+  (``yyyymmddHHMMSS``) to the filename (single) or create a
+  timestamped sub-folder (multi).  Defaults to ``False``.
 
 #### `export_excel()`
 
 ```python
-export_excel(path: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+export_excel(path: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
 ```
 
 Write report data to an Excel workbook at *path*.
 
-Each table is written as a separate worksheet.  For ``type="simple"`` a
-single ``transactions_table`` sheet is written; for ``type="full"`` six
-sheets are written (``statement``, ``account``, ``calendar``,
-``transactions``, ``balances``, ``gaps``).
+Each table is written as a separate worksheet.  For ``type="single"`` a
+single ``transactions`` sheet is written; for ``type="multi"`` six sheets
+are written (``statement_dimension``, ``account_dimension``,
+``calendar_dimension``, ``transaction_measures``,
+``daily_account_balances``, ``missing_statement_report``).
+
+Filename conventions:
+
+- ``type="single"``, no timestamp: ``transactions.xlsx``
+- ``type="single"``, with timestamp: ``transactions_20250331143022.xlsx``
+- ``type="multi"``, no timestamp: ``transactions_multi.xlsx``
+- ``type="multi"``, with timestamp: ``transactions_multi_20250331143022.xlsx``
+
+Worksheet names are never modified by the timestamp or type logic.
 
 
 **Args:**
@@ -334,25 +363,44 @@ sheets are written (``statement``, ``account``, ``calendar``,
 - `path` — Full file path for the output ``.xlsx`` workbook.  When ``None``
   the file is written to ``export/excel/transactions.xlsx`` inside the
   project directory resolved via *project_path*.
-- `type` — Export preset — ``"simple"`` (flat transactions table) or
-  ``"full"`` (separate star-schema sheets for loading into a
-  database).  Defaults to ``"simple"``.
+- `type` — Export preset — ``"single"`` (flat transactions table) or
+  ``"multi"`` (separate star-schema sheets for loading into a
+  database).  Defaults to ``"single"``.
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+- `batch_id` — Optional batch identifier to filter report data to a single
+  batch.  When ``None`` all rows are exported.
+- `filename_timestamp` — When ``True``, append a human-readable timestamp
+  (``yyyymmddHHMMSS``) to the workbook filename.  Worksheet names
+  are unaffected.  Defaults to ``False``.
 
 #### `export_json()`
 
 ```python
-export_json(folder: Path | None = None, type: str = 'simple', project_path: Path | None = None) -> None
+export_json(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
 ```
 
 Write report data to JSON files in *folder*.
 
 Each table is written as a separate ``.json`` file containing a JSON array
 of row objects, named after its logical table name (e.g.
-``transactions_table.json``, or ``statement.json``, ``account.json``, etc.
-for ``type="full"``).
+``transactions.json``, or ``statement_dimension.json``,
+``account_dimension.json``, etc. for ``type="multi"``).
+
+When *filename_timestamp* is ``True``:
+
+- ``type="single"``: the timestamp is appended to the filename, e.g.
+``transactions_20250331143022.json``.
+- ``type="multi"``: files are written into a ``multi_20250331143022/``
+sub-folder inside *folder* with their original names.
+
+When *filename_timestamp* is ``False``:
+
+- ``type="single"``: files are written directly to *folder* with their
+original names, e.g. ``transactions.json``.
+- ``type="multi"``: files are written into a ``multi/`` sub-folder inside
+*folder* with their original names.
 
 
 **Args:**
@@ -360,12 +408,17 @@ for ``type="full"``).
 - `folder` — Directory to write JSON files into.  When ``None`` the
   project's ``export/json/`` directory (resolved via *project_path*)
   is used and created automatically if absent.
-- `type` — Export preset — ``"simple"`` (flat transactions table) or
-  ``"full"`` (separate star-schema tables for loading into a
-  database).  Defaults to ``"simple"``.
+- `type` — Export preset — ``"single"`` (flat transactions table) or
+  ``"multi"`` (separate star-schema tables for loading into a
+  database).  Defaults to ``"single"``.
 - `project_path` — Optional project root used to resolve the default export
   folder and data sources.  Falls back to the bundled default project
   when ``None``.
+- `batch_id` — Optional batch identifier to filter report data to a single
+  batch.  When ``None`` all rows are exported.
+- `filename_timestamp` — When ``True``, append a human-readable timestamp
+  (``yyyymmddHHMMSS``) to the filename (single) or create a
+  timestamped sub-folder (multi).  Defaults to ``False``.
 
 #### `export_reporting_data()`
 
@@ -375,9 +428,10 @@ export_reporting_data(project_path: Path | None = None) -> None
 
 Write CSV reporting feeds to the project's ``reporting/data/`` sub-directories.
 
-Calls :func:`export_csv` twice — once with ``type="simple"`` writing to
-``reporting/data/simple/`` and once with ``type="full"`` writing to
-``reporting/data/full/``.  Both directories are created automatically if
+Calls :func:`export_csv` twice — once with ``type="single"`` writing to
+``reporting/data/single/`` and once with ``type="multi"`` writing to
+``reporting/data/multi/`` (created as a sub-folder of ``reporting/data/``
+by the multi-export logic).  Both directories are created automatically if
 absent.
 
 This produces a stable set of CSV files that external reporting tools
@@ -399,11 +453,11 @@ to know about the full export machinery.
 
     bsp.db.export_reporting_data(project_path=Path("/my/project"))
     # Writes:
-    #   /my/project/reporting/data/simple/transactions_table.csv
-    #   /my/project/reporting/data/full/statement.csv
-    #   /my/project/reporting/data/full/account.csv
-    #   /my/project/reporting/data/full/calendar.csv
-    #   /my/project/reporting/data/full/transactions.csv
-    #   /my/project/reporting/data/full/balances.csv
-    #   /my/project/reporting/data/full/gaps.csv
+    #   /my/project/reporting/data/single/transactions.csv
+    #   /my/project/reporting/data/multi/statement_dimension.csv
+    #   /my/project/reporting/data/multi/account_dimension.csv
+    #   /my/project/reporting/data/multi/calendar_dimension.csv
+    #   /my/project/reporting/data/multi/transaction_measures.csv
+    #   /my/project/reporting/data/multi/daily_account_balances.csv
+    #   /my/project/reporting/data/multi/missing_statement_report.csv
 ```

--- a/src/bank_statement_parser/__init__.py
+++ b/src/bank_statement_parser/__init__.py
@@ -40,7 +40,10 @@ DimAccount, FactTransaction, GapReport plus ``export_csv`` / ``export_excel``
 / ``export_json`` / ``export_reporting_data`` helpers.  Export functions accept
 an optional ``folder`` / ``path`` argument; when omitted they write to the
 project's ``export/csv/``, ``export/excel/``, ``export/json/``, or
-``reporting/data/simple|full/`` sub-directory automatically.
+``reporting/data/simple|full/`` sub-directory automatically.  All three export
+functions also accept ``batch_id: str | None`` to filter to a single batch and
+``filename_timestamp: bool`` to append a Unix timestamp to the output filename
+(or create a timestamped sub-folder for multi-file full exports).
 
     bsp.db.FlatTransaction(...)
     bsp.db.export_reporting_data(project_path=Path("/my/project"))  # reporting feeds

--- a/src/bank_statement_parser/cli.py
+++ b/src/bank_statement_parser/cli.py
@@ -143,6 +143,8 @@ def _cmd_process(args: argparse.Namespace) -> int:
         batch.export(
             filetype=args.export_format,
             type=args.export_type,
+            batch_id=args.batch_id if args.batch_id else None,
+            filename_timestamp=args.filename_timestamp,
         )
 
     # -- cleanup temp files --------------------------------------------------
@@ -322,12 +324,12 @@ def main() -> None:
     )
     proc.add_argument(
         "--export-type",
-        choices=["full", "simple"],
-        default="simple",
+        choices=["single", "multi"],
+        default="single",
         dest="export_type",
         help=(
-            "Export preset. 'simple' (default) exports a single flat "
-            "transactions table. 'full' exports separate star-schema "
+            "Export preset. 'single' (default) exports a single flat "
+            "transactions table. 'multi' exports separate star-schema "
             "tables (accounts, calendar, statements, transactions, "
             "balances, gaps) intended for loading into an external database."
         ),
@@ -345,6 +347,23 @@ def main() -> None:
         default=False,
         dest="no_copy",
         help="Skip copying source PDFs into the project statements/ directory.",
+    )
+    proc.add_argument(
+        "--batch-id",
+        metavar="ID",
+        dest="batch_id",
+        default=None,
+        help="Filter exports to a single batch identifier (default: export all batches).",
+    )
+    proc.add_argument(
+        "--filename-timestamp",
+        action="store_true",
+        default=False,
+        dest="filename_timestamp",
+        help=(
+            "Append a human-readable timestamp (yyyymmddHHMMSS) to exported filenames. "
+            "For multi exports (CSV/JSON) a timestamped sub-folder is created instead."
+        ),
     )
 
     args = parser.parse_args()

--- a/src/bank_statement_parser/dev.py
+++ b/src/bank_statement_parser/dev.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 
 # from bank_statement_parser import get_exchange_rates
-
 # import bank_statement_parser as bsp
 from bank_statement_parser.modules import statements
 
 
 def main():
-    project_path = Path("/home/boscorat/Downloads/2024/bsp_project")
+    project_path = Path("/home/boscorat/Projects/bsp_project")
     # bsp.anonymise_pdf(Path("/home/boscorat/Projects/tsb_spend_and_save_example_1.pdf"))
     # laptop
     # folder = Path("/Users/boscorat/Library/CloudStorage/OneDrive-Personal/OpenStan/Statements/HSBC/2024")
@@ -38,7 +37,7 @@ def main():
     # get_exchange_rates(project_path=project_path)
     # batch.copy_statements_to_project()
     # batch.delete_temp_files()
-    batch.export(filetype="all")  # writes Excel, CSV, and JSON
+    batch.export(filetype="all", filename_timestamp=True, type="multi")  # writes Excel, CSV, and JSON
     batch.export(filetype="reporting")  # writes Excel, CSV, and JSON
     # print(f"total: {batch.duration_secs}, process: {batch.process_secs}, parquet: {batch.parquet_secs}, db: {batch.db_secs}")
     # if batch.errors:

--- a/src/bank_statement_parser/modules/__init__.py
+++ b/src/bank_statement_parser/modules/__init__.py
@@ -24,10 +24,10 @@ functions.  Access them via the namespace:
 """
 
 import bank_statement_parser.modules.reports_db as db
-from bank_statement_parser.modules.import_config import copy_default_import_config
-from bank_statement_parser.modules.paths import copy_project_folders
 from bank_statement_parser.modules.data import Failure, ParquetFiles, PdfResult, Review, StatementInfo, Success
 from bank_statement_parser.modules.errors import StatementError
+from bank_statement_parser.modules.import_config import copy_default_import_config
+from bank_statement_parser.modules.paths import copy_project_folders
 from bank_statement_parser.modules.pdf_functions import get_table_from_region, page_crop, page_text, pdf_open, region_search
 from bank_statement_parser.modules.statements import (
     Statement,

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -187,14 +187,14 @@ class ProjectPaths:
         return self.reporting.joinpath("data")
 
     @property
-    def reporting_data_simple(self) -> Path:
-        """Reporting data directory for the simple (flat transactions) feed."""
-        return self.reporting_data.joinpath("simple")
+    def reporting_data_single(self) -> Path:
+        """Reporting data directory for the single (flat transactions) feed."""
+        return self.reporting_data.joinpath("single")
 
     @property
-    def reporting_data_full(self) -> Path:
-        """Reporting data directory for the full (star-schema) feed."""
-        return self.reporting_data.joinpath("full")
+    def reporting_data_multi(self) -> Path:
+        """Reporting data directory for the multi (star-schema) feed."""
+        return self.reporting_data.joinpath("multi")
 
     # ------------------------------------------------------------------
     # Statements directory
@@ -395,8 +395,8 @@ class ProjectPaths:
             self.csv,
             self.excel,
             self.json,
-            self.reporting_data_simple,
-            self.reporting_data_full,
+            self.reporting_data_single,
+            self.reporting_data_multi,
             self.log_debug,
         ):
             directory.mkdir(parents=True, exist_ok=True)

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -6,8 +6,8 @@ Functions:
     export_excel: Write all report sheets to a single Excel workbook
         (defaults to project export/excel/transactions.xlsx).
     export_json: Write all report JSON files to a folder (defaults to project export/json/).
-    export_reporting_data: Write CSV reporting feeds to reporting/data/simple/ and
-        reporting/data/full/ inside the project directory.
+    export_reporting_data: Write CSV reporting feeds to reporting/data/single/ and
+        reporting/data/multi/ inside the project directory.
     export_spec: Load a TOML export spec and write filtered, formatted export file(s).
 
 Classes:
@@ -16,7 +16,9 @@ Classes:
 """
 
 import sqlite3
+from datetime import datetime
 from pathlib import Path
+from typing import Literal
 
 import polars as pl
 from xlsxwriter import Workbook
@@ -85,9 +87,19 @@ def _read_data_filtered(db_path: Path, table_name: str, batch_table: str, batch_
 _FLOAT_TABLES: frozenset[str] = frozenset({"transaction_measures", "daily_account_balances"})
 
 
+def _ts() -> str:
+    """Return the current local datetime as a human-readable timestamp string.
+
+    Returns:
+        Datetime formatted as ``"yyyymmddHHMMSS"``, e.g. ``"20250331143022"``.
+    """
+    return datetime.now().strftime("%Y%m%d%H%M%S")
+
+
 def _collect_report_frames(
-    type: str,
+    type: Literal["single", "multi"],
     project_path: Path | None,
+    batch_id: str | None = None,
 ) -> list[tuple[str, pl.DataFrame]]:
     """Collect and return report DataFrames for the given export type.
 
@@ -95,96 +107,166 @@ def _collect_report_frames(
     The logical name is used by callers to derive file names or worksheet names.
 
     Args:
-        type: Export preset — ``"simple"`` (flat transactions table only) or
-            ``"full"`` (all six star-schema tables).
+        type: Export preset — ``"single"`` (flat transactions table only) or
+            ``"multi"`` (all six star-schema tables).
         project_path: Optional project root directory.  Falls back to the
             bundled default project when ``None``.
+        batch_id: Optional batch identifier to filter all report tables to a
+            single batch.  When ``None`` all rows are returned.
 
     Returns:
         A list of ``(name, DataFrame)`` tuples in export order.
     """
-    if type == "full":
+    if type == "multi":
         return [
-            ("statement_dimension", DimStatement(project_path).all.collect()),
-            ("account_dimension", DimAccount(project_path).all.collect()),
-            ("calendar_dimension", DimTime(project_path).all.collect()),
-            ("transaction_measures", FactTransaction(project_path).all.collect()),
-            ("daily_account_balances", FactBalance(project_path).all.collect()),
+            ("statement_dimension", DimStatement(project_path, batch_id).all.collect()),
+            ("account_dimension", DimAccount(project_path, batch_id).all.collect()),
+            ("calendar_dimension", DimTime(project_path, batch_id).all.collect()),
+            ("transaction_measures", FactTransaction(project_path, batch_id).all.collect()),
+            ("daily_account_balances", FactBalance(project_path, batch_id).all.collect()),
             ("missing_statement_report", GapReport(project_path).all.collect()),
         ]
-    # type == "simple"
+    # type == "single"
     return [
-        ("transactions", FlatTransaction(project_path).all.collect()),
+        ("transactions", FlatTransaction(project_path, batch_id).all.collect()),
     ]
 
 
 def export_csv(
     folder: Path | None = None,
-    type: str = "simple",
+    type: Literal["single", "multi"] = "single",
     project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
 ) -> None:
     """
     Write report data to CSV files in *folder*.
 
     Each table is written as a separate ``.csv`` file named after its logical
-    table name (e.g. ``transactions_table.csv``, or ``statement.csv``,
-    ``account.csv``, etc. for ``type="full"``).
+    table name (e.g. ``transactions.csv``, or ``statement_dimension.csv``,
+    ``account_dimension.csv``, etc. for ``type="multi"``).
+
+    When *filename_timestamp* is ``True``:
+
+    - ``type="single"``: the timestamp is appended to the filename, e.g.
+      ``transactions_20250331143022.csv``.
+    - ``type="multi"``: files are written into a ``multi_20250331143022/``
+      sub-folder inside *folder* with their original names.
+
+    When *filename_timestamp* is ``False``:
+
+    - ``type="single"``: files are written directly to *folder* with their
+      original names, e.g. ``transactions.csv``.
+    - ``type="multi"``: files are written into a ``multi/`` sub-folder inside
+      *folder* with their original names.
 
     Args:
         folder: Directory to write CSV files into.  When ``None`` the project's
             ``export/csv/`` directory (resolved via *project_path*) is used and
             created automatically if absent.
-        type: Export preset — ``"simple"`` (flat transactions table) or
-            ``"full"`` (separate star-schema tables for loading into a
-            database).  Defaults to ``"simple"``.
+        type: Export preset — ``"single"`` (flat transactions table) or
+            ``"multi"`` (separate star-schema tables for loading into a
+            database).  Defaults to ``"single"``.
         project_path: Optional project root used to resolve the default export
             folder and data sources.  Falls back to the bundled default project
             when ``None``.
+        batch_id: Optional batch identifier to filter report data to a single
+            batch.  When ``None`` all rows are exported.
+        filename_timestamp: When ``True``, append a human-readable timestamp
+            (``yyyymmddHHMMSS``) to the filename (single) or create a
+            timestamped sub-folder (multi).  Defaults to ``False``.
     """
     if folder is None:
         paths = ProjectPaths.resolve(project_path)
         paths.ensure_subdir_for_write(paths.csv)
         folder = paths.csv
-    for name, df in _collect_report_frames(type, project_path):
-        df.write_csv(
-            file=folder / f"{name}.csv",
-            separator=",",
-            include_header=True,
-            quote_style="non_numeric",
-            float_precision=2,
-        )
+    frames = _collect_report_frames(type, project_path, batch_id)
+    if type == "multi":
+        out_folder = folder / (f"multi_{_ts()}" if filename_timestamp else "multi")
+        out_folder.mkdir(parents=True, exist_ok=True)
+        for name, df in frames:
+            df.write_csv(
+                file=out_folder / f"{name}.csv",
+                separator=",",
+                include_header=True,
+                quote_style="non_numeric",
+                float_precision=2,
+            )
+    elif filename_timestamp:
+        ts = _ts()
+        for name, df in frames:
+            df.write_csv(
+                file=folder / f"{name}_{ts}.csv",
+                separator=",",
+                include_header=True,
+                quote_style="non_numeric",
+                float_precision=2,
+            )
+    else:
+        for name, df in frames:
+            df.write_csv(
+                file=folder / f"{name}.csv",
+                separator=",",
+                include_header=True,
+                quote_style="non_numeric",
+                float_precision=2,
+            )
 
 
 def export_excel(
     path: Path | None = None,
-    type: str = "simple",
+    type: Literal["single", "multi"] = "single",
     project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
 ) -> None:
     """
     Write report data to an Excel workbook at *path*.
 
-    Each table is written as a separate worksheet.  For ``type="simple"`` a
-    single ``transactions_table`` sheet is written; for ``type="full"`` six
-    sheets are written (``statement``, ``account``, ``calendar``,
-    ``transactions``, ``balances``, ``gaps``).
+    Each table is written as a separate worksheet.  For ``type="single"`` a
+    single ``transactions`` sheet is written; for ``type="multi"`` six sheets
+    are written (``statement_dimension``, ``account_dimension``,
+    ``calendar_dimension``, ``transaction_measures``,
+    ``daily_account_balances``, ``missing_statement_report``).
+
+    Filename conventions:
+
+    - ``type="single"``, no timestamp: ``transactions.xlsx``
+    - ``type="single"``, with timestamp: ``transactions_20250331143022.xlsx``
+    - ``type="multi"``, no timestamp: ``transactions_multi.xlsx``
+    - ``type="multi"``, with timestamp: ``transactions_multi_20250331143022.xlsx``
+
+    Worksheet names are never modified by the timestamp or type logic.
 
     Args:
         path: Full file path for the output ``.xlsx`` workbook.  When ``None``
             the file is written to ``export/excel/transactions.xlsx`` inside the
             project directory resolved via *project_path*.
-        type: Export preset — ``"simple"`` (flat transactions table) or
-            ``"full"`` (separate star-schema sheets for loading into a
-            database).  Defaults to ``"simple"``.
+        type: Export preset — ``"single"`` (flat transactions table) or
+            ``"multi"`` (separate star-schema sheets for loading into a
+            database).  Defaults to ``"single"``.
         project_path: Optional project root used to resolve the default export
             folder and data sources.  Falls back to the bundled default project
             when ``None``.
+        batch_id: Optional batch identifier to filter report data to a single
+            batch.  When ``None`` all rows are exported.
+        filename_timestamp: When ``True``, append a human-readable timestamp
+            (``yyyymmddHHMMSS``) to the workbook filename.  Worksheet names
+            are unaffected.  Defaults to ``False``.
     """
     if path is None:
         paths = ProjectPaths.resolve(project_path)
         paths.ensure_subdir_for_write(paths.excel)
         path = paths.excel / "transactions.xlsx"
+    if type == "multi":
+        if filename_timestamp:
+            path = path.parent / f"{path.stem}_multi_{_ts()}{path.suffix}"
+        else:
+            path = path.parent / f"{path.stem}_multi{path.suffix}"
+    elif filename_timestamp:
+        path = path.parent / f"{path.stem}_{_ts()}{path.suffix}"
     with Workbook(str(path)) as wb:
-        for name, df in _collect_report_frames(type, project_path):
+        for name, df in _collect_report_frames(type, project_path, batch_id):
             extra: dict = {"float_precision": 2} if name in _FLOAT_TABLES else {}
             df.write_excel(
                 workbook=wb,
@@ -198,43 +280,76 @@ def export_excel(
 
 def export_json(
     folder: Path | None = None,
-    type: str = "simple",
+    type: Literal["single", "multi"] = "single",
     project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
 ) -> None:
     """
     Write report data to JSON files in *folder*.
 
     Each table is written as a separate ``.json`` file containing a JSON array
     of row objects, named after its logical table name (e.g.
-    ``transactions_table.json``, or ``statement.json``, ``account.json``, etc.
-    for ``type="full"``).
+    ``transactions.json``, or ``statement_dimension.json``,
+    ``account_dimension.json``, etc. for ``type="multi"``).
+
+    When *filename_timestamp* is ``True``:
+
+    - ``type="single"``: the timestamp is appended to the filename, e.g.
+      ``transactions_20250331143022.json``.
+    - ``type="multi"``: files are written into a ``multi_20250331143022/``
+      sub-folder inside *folder* with their original names.
+
+    When *filename_timestamp* is ``False``:
+
+    - ``type="single"``: files are written directly to *folder* with their
+      original names, e.g. ``transactions.json``.
+    - ``type="multi"``: files are written into a ``multi/`` sub-folder inside
+      *folder* with their original names.
 
     Args:
         folder: Directory to write JSON files into.  When ``None`` the
             project's ``export/json/`` directory (resolved via *project_path*)
             is used and created automatically if absent.
-        type: Export preset — ``"simple"`` (flat transactions table) or
-            ``"full"`` (separate star-schema tables for loading into a
-            database).  Defaults to ``"simple"``.
+        type: Export preset — ``"single"`` (flat transactions table) or
+            ``"multi"`` (separate star-schema tables for loading into a
+            database).  Defaults to ``"single"``.
         project_path: Optional project root used to resolve the default export
             folder and data sources.  Falls back to the bundled default project
             when ``None``.
+        batch_id: Optional batch identifier to filter report data to a single
+            batch.  When ``None`` all rows are exported.
+        filename_timestamp: When ``True``, append a human-readable timestamp
+            (``yyyymmddHHMMSS``) to the filename (single) or create a
+            timestamped sub-folder (multi).  Defaults to ``False``.
     """
     if folder is None:
         paths = ProjectPaths.resolve(project_path)
         paths.ensure_subdir_for_write(paths.json)
         folder = paths.json
-    for name, df in _collect_report_frames(type, project_path):
-        df.write_json(folder / f"{name}.json")
+    frames = _collect_report_frames(type, project_path, batch_id)
+    if type == "multi":
+        out_folder = folder / (f"multi_{_ts()}" if filename_timestamp else "multi")
+        out_folder.mkdir(parents=True, exist_ok=True)
+        for name, df in frames:
+            df.write_json(out_folder / f"{name}.json")
+    elif filename_timestamp:
+        ts = _ts()
+        for name, df in frames:
+            df.write_json(folder / f"{name}_{ts}.json")
+    else:
+        for name, df in frames:
+            df.write_json(folder / f"{name}.json")
 
 
 def export_reporting_data(project_path: Path | None = None) -> None:
     """
     Write CSV reporting feeds to the project's ``reporting/data/`` sub-directories.
 
-    Calls :func:`export_csv` twice — once with ``type="simple"`` writing to
-    ``reporting/data/simple/`` and once with ``type="full"`` writing to
-    ``reporting/data/full/``.  Both directories are created automatically if
+    Calls :func:`export_csv` twice — once with ``type="single"`` writing to
+    ``reporting/data/single/`` and once with ``type="multi"`` writing to
+    ``reporting/data/multi/`` (created as a sub-folder of ``reporting/data/``
+    by the multi-export logic).  Both directories are created automatically if
     absent.
 
     This produces a stable set of CSV files that external reporting tools
@@ -252,19 +367,19 @@ def export_reporting_data(project_path: Path | None = None) -> None:
 
         bsp.db.export_reporting_data(project_path=Path("/my/project"))
         # Writes:
-        #   /my/project/reporting/data/simple/transactions_table.csv
-        #   /my/project/reporting/data/full/statement.csv
-        #   /my/project/reporting/data/full/account.csv
-        #   /my/project/reporting/data/full/calendar.csv
-        #   /my/project/reporting/data/full/transactions.csv
-        #   /my/project/reporting/data/full/balances.csv
-        #   /my/project/reporting/data/full/gaps.csv
+        #   /my/project/reporting/data/single/transactions.csv
+        #   /my/project/reporting/data/multi/statement_dimension.csv
+        #   /my/project/reporting/data/multi/account_dimension.csv
+        #   /my/project/reporting/data/multi/calendar_dimension.csv
+        #   /my/project/reporting/data/multi/transaction_measures.csv
+        #   /my/project/reporting/data/multi/daily_account_balances.csv
+        #   /my/project/reporting/data/multi/missing_statement_report.csv
     """
     paths = ProjectPaths.resolve(project_path)
-    paths.ensure_subdir_for_write(paths.reporting_data_simple)
-    paths.ensure_subdir_for_write(paths.reporting_data_full)
-    export_csv(folder=paths.reporting_data_simple, type="simple", project_path=project_path)
-    export_csv(folder=paths.reporting_data_full, type="full", project_path=project_path)
+    paths.ensure_subdir_for_write(paths.reporting_data_single)
+    paths.ensure_subdir_for_write(paths.reporting_data)
+    export_csv(folder=paths.reporting_data_single, type="single", project_path=project_path)
+    export_csv(folder=paths.reporting_data, type="multi", project_path=project_path)
 
 
 class FlatTransaction:
@@ -335,4 +450,4 @@ if __name__ == "__main__":
     pl.Config.set_tbl_rows(100)
     pl.Config.set_tbl_cols(55)
     pl.Config.set_fmt_str_lengths(25)
-    export_excel(ProjectPaths.resolve().excel.joinpath("test_db.xlsx"), type="simple")
+    export_excel(ProjectPaths.resolve().excel.joinpath("test_db.xlsx"), type="single")

--- a/src/bank_statement_parser/modules/statements.py
+++ b/src/bank_statement_parser/modules/statements.py
@@ -29,7 +29,6 @@ from uuid import uuid4
 import polars as pl
 
 import bank_statement_parser.modules.parquet as pq
-from bank_statement_parser.modules.import_config import ImportConfigManager
 from bank_statement_parser.modules.data import (
     Account,
     Failure,
@@ -41,6 +40,7 @@ from bank_statement_parser.modules.data import (
     Success,
 )
 from bank_statement_parser.modules.database import update_db
+from bank_statement_parser.modules.import_config import ImportConfigManager
 from bank_statement_parser.modules.parquet import update_parquet
 from bank_statement_parser.modules.paths import ProjectPaths, validate_or_initialise_project
 from bank_statement_parser.modules.pdf_functions import pdf_close, pdf_open
@@ -1351,8 +1351,10 @@ class StatementBatch:
         self,
         filetype: Literal["excel", "csv", "json", "all", "both", "reporting"] = "excel",
         folder: Path | None = None,
-        type: str = "simple",
+        type: Literal["single", "multi"] = "single",
         project_path: Path | None = None,
+        batch_id: str | None = None,
+        filename_timestamp: bool = False,
     ) -> None:
         """
         Export processed batch data to a file or set of files.
@@ -1367,8 +1369,8 @@ class StatementBatch:
                 workbook; ``"csv"`` writes one CSV file per report table;
                 ``"json"`` writes one JSON file per report table; ``"all"``
                 writes Excel, CSV, and JSON in sequence; ``"reporting"`` writes
-                CSV feeds to ``reporting/data/simple/`` and
-                ``reporting/data/full/`` inside the project directory.
+                CSV feeds to ``reporting/data/single/`` and
+                ``reporting/data/multi/`` inside the project directory.
                 Defaults to ``"excel"``.
 
                 .. deprecated::
@@ -1380,12 +1382,18 @@ class StatementBatch:
                 ``None`` the default export sub-directory for the resolved
                 project is used.
             type: Export preset passed through to the underlying function.
-                ``"simple"`` exports the flat transactions table only;
-                ``"full"`` exports separate star-schema tables for loading
-                into a database.  Defaults to ``"simple"``.
+                ``"single"`` exports the flat transactions table only;
+                ``"multi"`` exports separate star-schema tables for loading
+                into a database.  Defaults to ``"single"``.
             project_path: Optional project root directory.  If not provided,
                 uses the project_path set on this batch, or the default project
                 folder.
+            batch_id: Optional batch identifier to filter report data to a
+                single batch.  When ``None`` all rows are exported.
+            filename_timestamp: When ``True``, append a human-readable
+                timestamp (``yyyymmddHHMMSS``) to the output filename or create
+                a timestamped sub-folder for multi-file exports.  Defaults to
+                ``False``.
         """
         if filetype == "both":
             warnings.warn(
@@ -1395,20 +1403,47 @@ class StatementBatch:
             )
             filetype = "all"
         if filetype == "all":
-            self.export(filetype="excel", folder=folder, type=type, project_path=project_path)
-            self.export(filetype="csv", folder=folder, type=type, project_path=project_path)
-            self.export(filetype="json", folder=folder, type=type, project_path=project_path)
+            self.export(
+                filetype="excel",
+                folder=folder,
+                type=type,
+                project_path=project_path,
+                batch_id=batch_id,
+                filename_timestamp=filename_timestamp,
+            )
+            self.export(
+                filetype="csv",
+                folder=folder,
+                type=type,
+                project_path=project_path,
+                batch_id=batch_id,
+                filename_timestamp=filename_timestamp,
+            )
+            self.export(
+                filetype="json",
+                folder=folder,
+                type=type,
+                project_path=project_path,
+                batch_id=batch_id,
+                filename_timestamp=filename_timestamp,
+            )
             return
         resolved_project_path = project_path if project_path is not None else self.project_path
 
-        import bank_statement_parser.modules.reports_db as _rd
+        import bank_statement_parser.modules.reports_db as _rd  # noqa: PLC0415
 
         if filetype == "excel":
-            _rd.export_excel(path=folder, type=type, project_path=resolved_project_path)
+            _rd.export_excel(
+                path=folder, type=type, project_path=resolved_project_path, batch_id=batch_id, filename_timestamp=filename_timestamp
+            )
         elif filetype == "csv":
-            _rd.export_csv(folder=folder, type=type, project_path=resolved_project_path)
+            _rd.export_csv(
+                folder=folder, type=type, project_path=resolved_project_path, batch_id=batch_id, filename_timestamp=filename_timestamp
+            )
         elif filetype == "json":
-            _rd.export_json(folder=folder, type=type, project_path=resolved_project_path)
+            _rd.export_json(
+                folder=folder, type=type, project_path=resolved_project_path, batch_id=batch_id, filename_timestamp=filename_timestamp
+            )
         elif filetype == "reporting":
             _rd.export_reporting_data(project_path=resolved_project_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,14 +154,14 @@ class TestProcessOptions:
         assert action.default == "all"
 
     def test_export_type_choices(self) -> None:
-        """--export-type must accept full, simple."""
+        """--export-type must accept single, multi."""
         action = _find_action("process", "--export-type")
-        assert set(action.choices) == {"full", "simple"}
+        assert set(action.choices) == {"single", "multi"}
 
     def test_export_type_default(self) -> None:
-        """--export-type must default to 'simple'."""
+        """--export-type must default to 'single'."""
         action = _find_action("process", "--export-type")
-        assert action.default == "simple"
+        assert action.default == "single"
 
     def test_pattern_default(self) -> None:
         """--pattern must default to '**/*.pdf'."""

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -13,7 +13,7 @@ TestDbReports
 
 TestExports
     Verifies CSV, JSON, and Excel export functions for the database backend,
-    including full and simple presets, content/totals checks for CSV and JSON,
+    including multi and single presets, content/totals checks for CSV and JSON,
     the ``filetype="all"`` convenience mode on ``StatementBatch.export()``,
     and the deprecated ``filetype="both"`` alias.
 
@@ -159,8 +159,8 @@ class TestDbReports:
 # TestExports
 # ---------------------------------------------------------------------------
 
-# File names produced by ``type="full"`` exports (stem only, no extension).
-_FULL_EXPORT_STEMS = [
+# File names produced by ``type="multi"`` exports (stem only, no extension).
+_MULTI_EXPORT_STEMS = [
     "statement_dimension",
     "account_dimension",
     "calendar_dimension",
@@ -169,8 +169,8 @@ _FULL_EXPORT_STEMS = [
     "missing_statement_report",
 ]
 
-# Mapping from full-export logical name → DB table/view name (for row-count checks).
-_FULL_STEM_TO_DB_TABLE = {
+# Mapping from multi-export logical name → DB table/view name (for row-count checks).
+_MULTI_STEM_TO_DB_TABLE = {
     "statement_dimension": "DimStatement",
     "account_dimension": "DimAccount",
     "calendar_dimension": "DimTime",
@@ -184,7 +184,7 @@ class TestExports:
     """Verify CSV, JSON, and Excel exports for the database backend and presets.
 
     Content checks (row counts, monetary totals) are performed for CSV and JSON
-    ``type="simple"`` and ``type="full"`` exports.  Excel tests are
+    ``type="single"`` and ``type="multi"`` exports.  Excel tests are
     existence-only to avoid OS-dependent or extra-dependency parsing.
     """
 
@@ -192,30 +192,30 @@ class TestExports:
     # DB backend — CSV existence
     # ------------------------------------------------------------------
 
-    def test_db_export_csv_full(self, good_project):
-        """DB export_csv(type='full') writes all six CSV files."""
-        db.export_csv(type="full", project_path=good_project.project_path)
+    def test_db_export_csv_multi(self, good_project):
+        """DB export_csv(type='multi') writes all six CSV files in a multi/ subfolder."""
+        db.export_csv(type="multi", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        for stem in _FULL_EXPORT_STEMS:
-            f = paths.csv / f"{stem}.csv"
-            assert f.exists(), f"Missing CSV: {stem}.csv"
-            assert f.stat().st_size > 0, f"Empty CSV: {stem}.csv"
+        for stem in _MULTI_EXPORT_STEMS:
+            f = paths.csv / "multi" / f"{stem}.csv"
+            assert f.exists(), f"Missing CSV: multi/{stem}.csv"
+            assert f.stat().st_size > 0, f"Empty CSV: multi/{stem}.csv"
 
-    def test_db_export_csv_simple(self, good_project):
-        """DB export_csv(type='simple') writes the flat transactions CSV."""
-        db.export_csv(type="simple", project_path=good_project.project_path)
+    def test_db_export_csv_single(self, good_project):
+        """DB export_csv(type='single') writes the flat transactions CSV."""
+        db.export_csv(type="single", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         f = paths.csv / "transactions.csv"
-        assert f.exists(), "Missing transactions.csv (db/simple)"
-        assert f.stat().st_size > 0, "Empty transactions.csv (db/simple)"
+        assert f.exists(), "Missing transactions.csv (db/single)"
+        assert f.stat().st_size > 0, "Empty transactions.csv (db/single)"
 
     # ------------------------------------------------------------------
-    # DB backend — CSV content: simple totals
+    # DB backend — CSV content: single totals
     # ------------------------------------------------------------------
 
-    def test_csv_simple_totals(self, good_project):
-        """transactions_table.csv row count and monetary totals match the DB mart."""
-        db.export_csv(type="simple", project_path=good_project.project_path)
+    def test_csv_single_totals(self, good_project):
+        """transactions.csv row count and monetary totals match the DB mart."""
+        db.export_csv(type="single", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         df = pl.read_csv(paths.csv / "transactions.csv", schema_overrides={"account_number": pl.String})
 
@@ -231,67 +231,67 @@ class TestExports:
         assert abs(csv_value_out - db_value_out) <= FLOAT_TOL, f"value_out mismatch: CSV={csv_value_out} DB={db_value_out}"
 
     # ------------------------------------------------------------------
-    # DB backend — CSV content: full row counts
+    # DB backend — CSV content: multi row counts
     # ------------------------------------------------------------------
 
-    def test_csv_full_row_counts(self, good_project):
-        """Each full-export CSV file has the same row count as its DB source table."""
-        db.export_csv(type="full", project_path=good_project.project_path)
+    def test_csv_multi_row_counts(self, good_project):
+        """Each multi-export CSV file has the same row count as its DB source table."""
+        db.export_csv(type="multi", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         with sqlite3.connect(str(paths.project_db)) as conn:
-            for stem, table in _FULL_STEM_TO_DB_TABLE.items():
+            for stem, table in _MULTI_STEM_TO_DB_TABLE.items():
                 db_rows = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
-                df = pl.read_csv(paths.csv / f"{stem}.csv", infer_schema_length=0)
+                df = pl.read_csv(paths.csv / "multi" / f"{stem}.csv", infer_schema_length=0)
                 assert df.height == db_rows, f"{stem}.csv: CSV rows={df.height} != DB rows={db_rows}"
 
     # ------------------------------------------------------------------
     # DB backend — Excel existence only
     # ------------------------------------------------------------------
 
-    def test_db_export_excel_full(self, good_project):
-        """DB export_excel(type='full') writes a non-empty workbook."""
-        db.export_excel(type="full", project_path=good_project.project_path)
+    def test_db_export_excel_multi(self, good_project):
+        """DB export_excel(type='multi') writes a non-empty workbook named transactions_multi.xlsx."""
+        db.export_excel(type="multi", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        f = paths.excel / "transactions.xlsx"
-        assert f.exists(), "Missing transactions.xlsx (db/full)"
-        assert f.stat().st_size > 0, "Empty transactions.xlsx (db/full)"
+        f = paths.excel / "transactions_multi.xlsx"
+        assert f.exists(), "Missing transactions_multi.xlsx (db/multi)"
+        assert f.stat().st_size > 0, "Empty transactions_multi.xlsx (db/multi)"
 
-    def test_db_export_excel_simple(self, good_project):
-        """DB export_excel(type='simple') writes a non-empty workbook."""
-        db.export_excel(type="simple", project_path=good_project.project_path)
+    def test_db_export_excel_single(self, good_project):
+        """DB export_excel(type='single') writes a non-empty workbook."""
+        db.export_excel(type="single", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         f = paths.excel / "transactions.xlsx"
-        assert f.exists(), "Missing transactions.xlsx (db/simple)"
-        assert f.stat().st_size > 0, "Empty transactions.xlsx (db/simple)"
+        assert f.exists(), "Missing transactions.xlsx (db/single)"
+        assert f.stat().st_size > 0, "Empty transactions.xlsx (db/single)"
 
     # ------------------------------------------------------------------
     # DB backend — JSON existence
     # ------------------------------------------------------------------
 
-    def test_db_export_json_full(self, good_project):
-        """DB export_json(type='full') writes all six JSON files."""
-        db.export_json(type="full", project_path=good_project.project_path)
+    def test_db_export_json_multi(self, good_project):
+        """DB export_json(type='multi') writes all six JSON files in a multi/ subfolder."""
+        db.export_json(type="multi", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        for stem in _FULL_EXPORT_STEMS:
-            f = paths.json / f"{stem}.json"
-            assert f.exists(), f"Missing JSON: {stem}.json"
-            assert f.stat().st_size > 0, f"Empty JSON: {stem}.json"
+        for stem in _MULTI_EXPORT_STEMS:
+            f = paths.json / "multi" / f"{stem}.json"
+            assert f.exists(), f"Missing JSON: multi/{stem}.json"
+            assert f.stat().st_size > 0, f"Empty JSON: multi/{stem}.json"
 
-    def test_db_export_json_simple(self, good_project):
-        """DB export_json(type='simple') writes the flat transactions JSON."""
-        db.export_json(type="simple", project_path=good_project.project_path)
+    def test_db_export_json_single(self, good_project):
+        """DB export_json(type='single') writes the flat transactions JSON."""
+        db.export_json(type="single", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         f = paths.json / "transactions.json"
-        assert f.exists(), "Missing transactions.json (db/simple)"
-        assert f.stat().st_size > 0, "Empty transactions.json (db/simple)"
+        assert f.exists(), "Missing transactions.json (db/single)"
+        assert f.stat().st_size > 0, "Empty transactions.json (db/single)"
 
     # ------------------------------------------------------------------
-    # DB backend — JSON content: simple totals
+    # DB backend — JSON content: single totals
     # ------------------------------------------------------------------
 
-    def test_json_simple_totals(self, good_project):
-        """transactions_table.json row count and monetary totals match the DB mart."""
-        db.export_json(type="simple", project_path=good_project.project_path)
+    def test_json_single_totals(self, good_project):
+        """transactions.json row count and monetary totals match the DB mart."""
+        db.export_json(type="single", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         df = pl.read_json(paths.json / "transactions.json")
 
@@ -307,17 +307,17 @@ class TestExports:
         assert abs(json_value_out - db_value_out) <= FLOAT_TOL, f"value_out mismatch: JSON={json_value_out} DB={db_value_out}"
 
     # ------------------------------------------------------------------
-    # DB backend — JSON content: full row counts
+    # DB backend — JSON content: multi row counts
     # ------------------------------------------------------------------
 
-    def test_json_full_row_counts(self, good_project):
-        """Each full-export JSON file has the same row count as its DB source table."""
-        db.export_json(type="full", project_path=good_project.project_path)
+    def test_json_multi_row_counts(self, good_project):
+        """Each multi-export JSON file has the same row count as its DB source table."""
+        db.export_json(type="multi", project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
         with sqlite3.connect(str(paths.project_db)) as conn:
-            for stem, table in _FULL_STEM_TO_DB_TABLE.items():
+            for stem, table in _MULTI_STEM_TO_DB_TABLE.items():
                 db_rows = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
-                df = pl.read_json(paths.json / f"{stem}.json", infer_schema_length=None)
+                df = pl.read_json(paths.json / "multi" / f"{stem}.json", infer_schema_length=None)
                 assert df.height == db_rows, f"{stem}.json: JSON rows={df.height} != DB rows={db_rows}"
 
     # ------------------------------------------------------------------
@@ -326,22 +326,22 @@ class TestExports:
 
     def test_batch_export_all(self, good_project):
         """StatementBatch.export(filetype='all') writes Excel, CSV, and JSON."""
-        good_project.batch.export(filetype="all", type="full")
+        good_project.batch.export(filetype="all", type="multi")
         paths = ProjectPaths.resolve(good_project.project_path)
         # Excel
-        xlsx = paths.excel / "transactions.xlsx"
-        assert xlsx.exists(), "Missing transactions.xlsx after filetype='all'"
-        assert xlsx.stat().st_size > 0, "Empty transactions.xlsx after filetype='all'"
+        xlsx = paths.excel / "transactions_multi.xlsx"
+        assert xlsx.exists(), "Missing transactions_multi.xlsx after filetype='all'"
+        assert xlsx.stat().st_size > 0, "Empty transactions_multi.xlsx after filetype='all'"
         # CSV
-        for stem in _FULL_EXPORT_STEMS:
-            f = paths.csv / f"{stem}.csv"
-            assert f.exists(), f"Missing CSV after filetype='all': {stem}.csv"
-            assert f.stat().st_size > 0, f"Empty CSV after filetype='all': {stem}.csv"
+        for stem in _MULTI_EXPORT_STEMS:
+            f = paths.csv / "multi" / f"{stem}.csv"
+            assert f.exists(), f"Missing CSV after filetype='all': multi/{stem}.csv"
+            assert f.stat().st_size > 0, f"Empty CSV after filetype='all': multi/{stem}.csv"
         # JSON
-        for stem in _FULL_EXPORT_STEMS:
-            f = paths.json / f"{stem}.json"
-            assert f.exists(), f"Missing JSON after filetype='all': {stem}.json"
-            assert f.stat().st_size > 0, f"Empty JSON after filetype='all': {stem}.json"
+        for stem in _MULTI_EXPORT_STEMS:
+            f = paths.json / "multi" / f"{stem}.json"
+            assert f.exists(), f"Missing JSON after filetype='all': multi/{stem}.json"
+            assert f.stat().st_size > 0, f"Empty JSON after filetype='all': multi/{stem}.json"
 
     # ------------------------------------------------------------------
     # StatementBatch.export() — filetype="both" deprecated alias
@@ -351,11 +351,11 @@ class TestExports:
         """filetype='both' emits a DeprecationWarning and still produces output."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            good_project.batch.export(filetype="both", type="simple")
+            good_project.batch.export(filetype="both", type="single")
         dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert len(dep_warnings) == 1, "Expected exactly one DeprecationWarning for filetype='both'"
         assert "filetype='both'" in str(dep_warnings[0].message)
-        # Output should still be written (all three formats, simple preset)
+        # Output should still be written (all three formats, single preset)
         paths = ProjectPaths.resolve(good_project.project_path)
         assert (paths.excel / "transactions.xlsx").exists()
         assert (paths.csv / "transactions.csv").exists()
@@ -365,30 +365,30 @@ class TestExports:
     # DB backend — export_reporting_data existence
     # ------------------------------------------------------------------
 
-    def test_reporting_data_simple_exists(self, good_project):
-        """export_reporting_data() writes transactions.csv to reporting/data/simple/."""
+    def test_reporting_data_single_exists(self, good_project):
+        """export_reporting_data() writes transactions.csv to reporting/data/single/."""
         db.export_reporting_data(project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        f = paths.reporting_data_simple / "transactions.csv"
-        assert f.exists(), "Missing reporting/data/simple/transactions.csv"
-        assert f.stat().st_size > 0, "Empty reporting/data/simple/transactions.csv"
+        f = paths.reporting_data_single / "transactions.csv"
+        assert f.exists(), "Missing reporting/data/single/transactions.csv"
+        assert f.stat().st_size > 0, "Empty reporting/data/single/transactions.csv"
 
-    def test_reporting_data_full_exists(self, good_project):
-        """export_reporting_data() writes all six CSVs to reporting/data/full/."""
+    def test_reporting_data_multi_exists(self, good_project):
+        """export_reporting_data() writes all six CSVs to reporting/data/multi/."""
         db.export_reporting_data(project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        for stem in _FULL_EXPORT_STEMS:
-            f = paths.reporting_data_full / f"{stem}.csv"
-            assert f.exists(), f"Missing reporting/data/full/{stem}.csv"
-            assert f.stat().st_size > 0, f"Empty reporting/data/full/{stem}.csv"
+        for stem in _MULTI_EXPORT_STEMS:
+            f = paths.reporting_data_multi / f"{stem}.csv"
+            assert f.exists(), f"Missing reporting/data/multi/{stem}.csv"
+            assert f.stat().st_size > 0, f"Empty reporting/data/multi/{stem}.csv"
 
     def test_batch_export_reporting(self, good_project):
         """StatementBatch.export(filetype='reporting') populates both reporting directories."""
         good_project.batch.export(filetype="reporting")
         paths = ProjectPaths.resolve(good_project.project_path)
-        assert (paths.reporting_data_simple / "transactions.csv").exists()
-        for stem in _FULL_EXPORT_STEMS:
-            assert (paths.reporting_data_full / f"{stem}.csv").exists()
+        assert (paths.reporting_data_single / "transactions.csv").exists()
+        for stem in _MULTI_EXPORT_STEMS:
+            assert (paths.reporting_data_multi / f"{stem}.csv").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -355,31 +355,31 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.3"
+version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ae/3936f79adebf8caf81bd7a599b90a561334a658be4dcc7b6329ebf4ee8de/numpy-2.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5884ce5c7acfae1e4e1b6fde43797d10aa506074d25b531b4f54bde33c0c31d4", size = 16664563, upload-time = "2026-03-09T07:57:43.817Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168", size = 14702161, upload-time = "2026-03-09T07:57:46.169Z" },
-    { url = "https://files.pythonhosted.org/packages/32/af/a7a39464e2c0a21526fb4fb76e346fb172ebc92f6d1c7a07c2c139cc17b1/numpy-2.4.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a111698b4a3f8dcbe54c64a7708f049355abd603e619013c346553c1fd4ca90b", size = 5208738, upload-time = "2026-03-09T07:57:48.506Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8c/2a0cf86a59558fa078d83805589c2de490f29ed4fb336c14313a161d358a/numpy-2.4.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:4bd4741a6a676770e0e97fe9ab2e51de01183df3dcbcec591d26d331a40de950", size = 6543618, upload-time = "2026-03-09T07:57:50.591Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b8/612ce010c0728b1c363fa4ea3aa4c22fe1c5da1de008486f8c2f5cb92fae/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd", size = 15680676, upload-time = "2026-03-09T07:57:52.34Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24", size = 16613492, upload-time = "2026-03-09T07:57:54.91Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/86/1b6020db73be330c4b45d5c6ee4295d59cfeef0e3ea323959d053e5a6909/numpy-2.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d84f0f881cb2225c2dfd7f78a10a5645d487a496c6668d6cc39f0f114164f3d0", size = 17031789, upload-time = "2026-03-09T07:57:57.641Z" },
-    { url = "https://files.pythonhosted.org/packages/07/3a/3b90463bf41ebc21d1b7e06079f03070334374208c0f9a1f05e4ae8455e7/numpy-2.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d213c7e6e8d211888cc359bab7199670a00f5b82c0978b9d1c75baf1eddbeac0", size = 18339941, upload-time = "2026-03-09T07:58:00.577Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/74/6d736c4cd962259fd8bae9be27363eb4883a2f9069763747347544c2a487/numpy-2.4.3-cp314-cp314-win32.whl", hash = "sha256:52077feedeff7c76ed7c9f1a0428558e50825347b7545bbb8523da2cd55c547a", size = 6007503, upload-time = "2026-03-09T07:58:03.331Z" },
-    { url = "https://files.pythonhosted.org/packages/48/39/c56ef87af669364356bb011922ef0734fc49dad51964568634c72a009488/numpy-2.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:0448e7f9caefb34b4b7dd2b77f21e8906e5d6f0365ad525f9f4f530b13df2afc", size = 12444915, upload-time = "2026-03-09T07:58:06.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/1f/ab8528e38d295fd349310807496fabb7cf9fe2e1f70b97bc20a483ea9d4a/numpy-2.4.3-cp314-cp314-win_arm64.whl", hash = "sha256:b44fd60341c4d9783039598efadd03617fa28d041fc37d22b62d08f2027fa0e7", size = 10494875, upload-time = "2026-03-09T07:58:08.734Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ef/b7c35e4d5ef141b836658ab21a66d1a573e15b335b1d111d31f26c8ef80f/numpy-2.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a195f4216be9305a73c0e91c9b026a35f2161237cf1c6de9b681637772ea657", size = 14822225, upload-time = "2026-03-09T07:58:11.034Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8d/7730fa9278cf6648639946cc816e7cc89f0d891602584697923375f801ed/numpy-2.4.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:cd32fbacb9fd1bf041bf8e89e4576b6f00b895f06d00914820ae06a616bdfef7", size = 5328769, upload-time = "2026-03-09T07:58:13.67Z" },
-    { url = "https://files.pythonhosted.org/packages/47/01/d2a137317c958b074d338807c1b6a383406cdf8b8e53b075d804cc3d211d/numpy-2.4.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:2e03c05abaee1f672e9d67bc858f300b5ccba1c21397211e8d77d98350972093", size = 6649461, upload-time = "2026-03-09T07:58:15.912Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/34/812ce12bc0f00272a4b0ec0d713cd237cb390666eb6206323d1cc9cedbb2/numpy-2.4.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d1ce23cce91fcea443320a9d0ece9b9305d4368875bab09538f7a5b4131938a", size = 15725809, upload-time = "2026-03-09T07:58:17.787Z" },
-    { url = "https://files.pythonhosted.org/packages/25/c0/2aed473a4823e905e765fee3dc2cbf504bd3e68ccb1150fbdabd5c39f527/numpy-2.4.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c59020932feb24ed49ffd03704fbab89f22aa9c0d4b180ff45542fe8918f5611", size = 16655242, upload-time = "2026-03-09T07:58:20.476Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c8/7e052b2fc87aa0e86de23f20e2c42bd261c624748aa8efd2c78f7bb8d8c6/numpy-2.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9684823a78a6cd6ad7511fc5e25b07947d1d5b5e2812c93fe99d7d4195130720", size = 17080660, upload-time = "2026-03-09T07:58:23.067Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/3d/0876746044db2adcb11549f214d104f2e1be00f07a67edbb4e2812094847/numpy-2.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0200b25c687033316fb39f0ff4e3e690e8957a2c3c8d22499891ec58c37a3eb5", size = 18380384, upload-time = "2026-03-09T07:58:25.839Z" },
-    { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
 ]
 
 [[package]]
@@ -605,24 +605,24 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.0"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -706,9 +706,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.29"
+version = "0.0.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -893,18 +893,18 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/bd/5786ab618a60bd7469ab243a7fd2c9eecb0790c85c784abb8b97edb77a54/zensical-0.0.29.tar.gz", hash = "sha256:0d6282be7cb551e12d5806badf5e94c54a5e2f2cf07057a3e36d1eaf97c33ada", size = 3842641, upload-time = "2026-03-24T13:37:27.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/53/5e551f8912718816733a75adcb53a0787b2d2edca5869c156325aaf82e24/zensical-0.0.30.tar.gz", hash = "sha256:408b531683f6bcb6cc5ab928146d2c68afbc16fac4eda87ae3dd20af1498180f", size = 3844287, upload-time = "2026-03-28T17:55:52.836Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/9c/8b681daa024abca9763017bec09ecee8008e110cae1254217c8dd22cc339/zensical-0.0.29-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:20ae0709ea14fce25ab33d0a82acdaf454a7a2e232a9ee20c019942205174476", size = 12311399, upload-time = "2026-03-24T13:36:53.809Z" },
-    { url = "https://files.pythonhosted.org/packages/81/ae/4ebb4d8bb2ef0164d473698b92f11caf431fc436e1625524acd5641102ca/zensical-0.0.29-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:599af3ba66fcd0146d7019f3493ed3c316051fae6c4d5599bc59f3a8f4b8a6f0", size = 12191845, upload-time = "2026-03-24T13:36:56.909Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/35/67f89db06571a52283b3ecbe3bcf32fd3115ca50436b3ae177a948b83ea7/zensical-0.0.29-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eea7e48a00a71c0586e875079b5f83a070c33a147e52ad4383e4b63ab524332b", size = 12554105, upload-time = "2026-03-24T13:36:59.945Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f6/ac79e5d9c18b28557c9ff1c7c23d695fbdd82645d69bfe02292f46d935e7/zensical-0.0.29-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59a57db35542e98d2896b833de07d199320f8ada3b4e7ddccb7fe892292d8b74", size = 12498643, upload-time = "2026-03-24T13:37:02.376Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/70/5c22a96a69e0e91e569c26236918bb9bab1170f59b29ad04105ead64f199/zensical-0.0.29-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d42c2b2a96a80cf64c98ba7242f59ef95109914bd4c9499d7ebc12544663852c", size = 12854531, upload-time = "2026-03-24T13:37:04.962Z" },
-    { url = "https://files.pythonhosted.org/packages/79/25/e32237a8fcb0ceae1ef8e192e7f8db53b38f1e48f1c7cdbacd0a7b713892/zensical-0.0.29-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b2fca39c5f6b1782c77cf6591cf346357cabee85ebdb956c5ddc0fd5169f3d9", size = 12596828, upload-time = "2026-03-24T13:37:07.817Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/74/89ac909cbb258903ea53802c184e4986c17ce0ba79b1c7f77b7e78a2dce3/zensical-0.0.29-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfc23a74ef672aa51088c080286319da1dc0b989cd5051e9e5e6d7d4abbc2fc1", size = 12732059, upload-time = "2026-03-24T13:37:11.651Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/31/2429de6a9328eed4acc7e9a3789f160294a15115be15f9870a0d02649302/zensical-0.0.29-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c9336d4e4b232e3c9a70e30258e916dd7e60c0a2a08c8690065e60350c302028", size = 12768542, upload-time = "2026-03-24T13:37:14.39Z" },
-    { url = "https://files.pythonhosted.org/packages/10/8a/55588b2a1dcbe86dad0404506c9ba367a06c663b1ff47147c84d26f7510e/zensical-0.0.29-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:30661148f0681199f3b598cbeb1d54f5cba773e54ae840bac639250d85907b84", size = 12917991, upload-time = "2026-03-24T13:37:16.795Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/5d/653901f0d3a3ca72daebc62746a148797f4e422cc3a2b66a4e6718e4398f/zensical-0.0.29-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6a566ac1fd4bfac5d711a7bd1ae06666712127c2718daa5083c7bf3f107e8578", size = 12868392, upload-time = "2026-03-24T13:37:19.42Z" },
-    { url = "https://files.pythonhosted.org/packages/29/58/d7449bc88a174b98daa3f2fbdfbdac3493768a557d8987e88bdaa6c78b1a/zensical-0.0.29-cp310-abi3-win32.whl", hash = "sha256:a231a3a02a3851741dc4d2de8910b5c39fe81e55bf026d8edf4d803e91a922fb", size = 11905486, upload-time = "2026-03-24T13:37:22.154Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/09/3fd082d016497c4d26ff20f42a8be2cc91e27191c0c5f3cd6507827f666f/zensical-0.0.29-cp310-abi3-win_amd64.whl", hash = "sha256:7145c5504380a344b8cd4586da815cdde77ef4a42319fa4f35e78250f01985af", size = 12101510, upload-time = "2026-03-24T13:37:24.77Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e3/ac0eb77a8a7f793613813de68bde26776d0da68d8041fa9eb8d0b986a449/zensical-0.0.30-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b67fca8bfcd71c94b331045a591bf6e24fe123a66fba94587aa3379faf521a16", size = 12313786, upload-time = "2026-03-28T17:55:18.839Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6a/73e461dfa27d3bc415e48396f83a3287b43df2fd3361e25146bc86360aab/zensical-0.0.30-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8ceadfece1153edc26506e8ddf68d9818afe8517cf3bcdb6bfe4cb2793ae247b", size = 12186136, upload-time = "2026-03-28T17:55:21.836Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/bc/9022156b4c28c1b95209acb64319b1e5cd0af2e97035bdd461e58408cb46/zensical-0.0.30-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e100b2b654337ac5306ba12818f3c5336c66d0d34c593ef05e316c124a5819cb", size = 12556115, upload-time = "2026-03-28T17:55:24.849Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/29/9e8f5bd6d33b35f4c368ae8b13d431dc42b2de17ea6eccbd71d48122eba6/zensical-0.0.30-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bdf641ffddaf21c6971b91a4426b81cd76271c5b1adb7176afcce3f1508328b1", size = 12498121, upload-time = "2026-03-28T17:55:27.637Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e1/b8dfa0769050e62cd731358145fdeb67af35e322197bd7e7727250596e7b/zensical-0.0.30-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd909a0c2116e26190c7f3ec4fb55837c417b7a8d99ebf4f3deb26b07b97e49", size = 12854142, upload-time = "2026-03-28T17:55:30.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/11/62a36cfb81522b6108db8f9e96d36da8cccb306b02c15ad19e1b333fa7c8/zensical-0.0.30-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16fd2da09fe4e5cbec2ca74f31abc70f32f7330d56593b647e0a114bb329171a", size = 12598341, upload-time = "2026-03-28T17:55:32.988Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a4/8c7a6725fb226aa71d19209403d974e45f39d757e725f9558c6ed8d350a5/zensical-0.0.30-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:896b36eaef7fed5f8fc6f2c8264b2751aad63c2d66d3d8650e38481b6b4f6f7b", size = 12732307, upload-time = "2026-03-28T17:55:35.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a1/7858fb3f6ac67d7d24a8acbe834cbe26851d6bd151ece6fba3fc88b0f878/zensical-0.0.30-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:a1f515ec67a0d0250e53846327bf0c69635a1f39749da3b04feb68431188d3c6", size = 12770962, upload-time = "2026-03-28T17:55:38.627Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/228298112a69d0b74e6e93041bffcf1fc96d03cf252be94a354f277d4789/zensical-0.0.30-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce33d1002438838a35fa43358a1f43d74f874586596d3d116999d3756cded00e", size = 12919256, upload-time = "2026-03-28T17:55:41.413Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c7/5b4ea036f7f7d84abf907f7f7a3e8420b054c89279c5273ca248d3bc9f48/zensical-0.0.30-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:029dad561568f4ae3056dde16a81012efd92c426d4eb7101f960f448c1168196", size = 12869760, upload-time = "2026-03-28T17:55:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b4/77bef2132e43108db718ae014a5961fc511e88fc446c11f1c3483def429e/zensical-0.0.30-cp310-abi3-win32.whl", hash = "sha256:0105672850f053c326fba9fdd95adf60e9f90308f8cc1c08e3a00e15a8d5e90f", size = 11905658, upload-time = "2026-03-28T17:55:47.416Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/59/23b6c7ff062e2b299cc60e333095e853f9d38d1b5abe743c7b94c4ac432c/zensical-0.0.30-cp310-abi3-win_amd64.whl", hash = "sha256:b879dbf4c69d3ea41694bae33e1b948847e635dcbcd6ec8c522920833379dd48", size = 12101867, upload-time = "2026-03-28T17:55:50.083Z" },
 ]


### PR DESCRIPTION
## Summary

- **Rename export type values**: `'simple'` → `'single'` and `'full'` → `'multi'` across the entire codebase (`reports_db.py`, `statements.py`, `cli.py`, `paths.py`, tests, and docs)
- **Human-readable timestamps**: `_ts()` now returns `yyyymmddHHMMSS` strings (e.g. `20250331143022`) instead of Unix integer strings
- **Stricter typing**: export `type` parameter annotation tightened from `str` to `Literal["single", "multi"]` everywhere
- **Consistent multi-export layout**: Excel multi exports always include `_multi` in the filename; CSV/JSON multi exports always group files under a `multi[_TIMESTAMP]/` subfolder
- **Path properties renamed**: `paths.reporting_data_simple` / `reporting_data_full` → `reporting_data_single` / `reporting_data_multi` (with matching folder paths `reporting/data/single/` and `reporting/data/multi/`)
- **Docs regenerated** to reflect updated CLI choices and Python API signatures

## Test Results

202/202 tests passing. Ruff lint and format checks clean.