### PR TITLE
refactor: rename DimTime→DimDate, *_id→*_int surrogate keys, add id_account to DimStatement

### DIFF
--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -203,7 +203,7 @@ Extract a structured table from a PDF region using configurable extraction setti
 
 *function* — `bank_statement_parser.data`
 
-Empty and rebuild all mart tables (DimTime, DimAccount, DimStatement, FactTransaction, FactBalance) from the raw source tables.
+Empty and rebuild all mart tables (DimDate, DimAccount, DimStatement, FactTransaction, FactBalance) from the raw source tables.
 
 ### `bsp.create_db()`
 

--- a/src/bank_statement_parser/data/build_datamart.py
+++ b/src/bank_statement_parser/data/build_datamart.py
@@ -8,9 +8,9 @@ from pathlib import Path
 # Mart table DDL
 # ---------------------------------------------------------------------------
 
-_DDL_DIM_TIME = """
-    CREATE TABLE DimTime (
-        time_id              INTEGER NOT NULL PRIMARY KEY,
+_DDL_DIM_DATE = """
+    CREATE TABLE DimDate (
+        date_int             INTEGER NOT NULL PRIMARY KEY,
         id_date              TEXT    NOT NULL UNIQUE,
         date_local_format    TEXT,
         date_integer         INTEGER,
@@ -40,7 +40,7 @@ _DDL_DIM_TIME = """
 
 _DDL_DIM_ACCOUNT = """
     CREATE TABLE DimAccount (
-        account_id      INTEGER NOT NULL PRIMARY KEY,
+        account_int     INTEGER NOT NULL PRIMARY KEY,
         id_account      TEXT    NOT NULL UNIQUE,
         company         TEXT,
         account_type    TEXT,
@@ -53,9 +53,10 @@ _DDL_DIM_ACCOUNT = """
 
 _DDL_DIM_STATEMENT = """
     CREATE TABLE DimStatement (
-        statement_id    INTEGER NOT NULL PRIMARY KEY,
+        statement_int   INTEGER NOT NULL PRIMARY KEY,
         id_statement    TEXT    NOT NULL UNIQUE,
-        account_id      INTEGER NOT NULL REFERENCES DimAccount(account_id),
+        account_int     INTEGER NOT NULL REFERENCES DimAccount(account_int),
+        id_account      TEXT    NOT NULL,
         id_batch        TEXT,
         company         TEXT,
         account_type    TEXT,
@@ -76,37 +77,37 @@ _DDL_DIM_STATEMENT = """
 
 _DDL_FACT_TRANSACTION = """
     CREATE TABLE FactTransaction (
-        transaction_id          INTEGER NOT NULL PRIMARY KEY,
-        id_transaction          TEXT    NOT NULL UNIQUE,
-        statement_id            INTEGER NOT NULL REFERENCES DimStatement(statement_id),
-        account_id              INTEGER NOT NULL REFERENCES DimAccount(account_id),
-        time_id                 INTEGER NOT NULL REFERENCES DimTime(time_id),
-        id_date                 TEXT    NOT NULL,
-        id_account              TEXT    NOT NULL,
-        id_statement            TEXT    NOT NULL,
-        transaction_number      INTEGER,
+        transaction_int             INTEGER NOT NULL PRIMARY KEY,
+        id_transaction              TEXT    NOT NULL UNIQUE,
+        statement_int               INTEGER NOT NULL REFERENCES DimStatement(statement_int),
+        account_int                 INTEGER NOT NULL REFERENCES DimAccount(account_int),
+        date_int                    INTEGER NOT NULL REFERENCES DimDate(date_int),
+        id_date                     TEXT    NOT NULL,
+        id_account                  TEXT    NOT NULL,
+        id_statement                TEXT    NOT NULL,
+        transaction_number          INTEGER,
         transaction_credit_or_debit TEXT,
-        transaction_type        TEXT,
-        transaction_type_cd     TEXT,
-        transaction_desc        TEXT,
-        opening_balance         REAL,
-        value_in                REAL,
-        value_out               REAL,
-        value                   REAL
+        transaction_type            TEXT,
+        transaction_type_cd         TEXT,
+        transaction_desc            TEXT,
+        opening_balance             REAL,
+        value_in                    REAL,
+        value_out                   REAL,
+        value                       REAL
     )
 """
 
 _DDL_FACT_BALANCE = """
     CREATE TABLE FactBalance (
-        time_id          INTEGER NOT NULL REFERENCES DimTime(time_id),
-        account_id       INTEGER NOT NULL REFERENCES DimAccount(account_id),
+        date_int         INTEGER NOT NULL REFERENCES DimDate(date_int),
+        account_int      INTEGER NOT NULL REFERENCES DimAccount(account_int),
         id_date          TEXT    NOT NULL,
         id_account       TEXT    NOT NULL,
         opening_balance  REAL,
         closing_balance  REAL,
         movement         REAL    NOT NULL DEFAULT 0,
         outside_date     INTEGER NOT NULL DEFAULT 0,
-        PRIMARY KEY (time_id, account_id)
+        PRIMARY KEY (date_int, account_int)
     )
 """
 
@@ -117,9 +118,9 @@ _DDL_FACT_BALANCE = """
 # drop-and-recreate build steps and intentionally omit IF NOT EXISTS.
 # ---------------------------------------------------------------------------
 
-_DDL_DIM_TIME_ENSURE = """
-    CREATE TABLE IF NOT EXISTS DimTime (
-        time_id              INTEGER NOT NULL PRIMARY KEY,
+_DDL_DIM_DATE_ENSURE = """
+    CREATE TABLE IF NOT EXISTS DimDate (
+        date_int             INTEGER NOT NULL PRIMARY KEY,
         id_date              TEXT    NOT NULL UNIQUE,
         date_local_format    TEXT,
         date_integer         INTEGER,
@@ -149,7 +150,7 @@ _DDL_DIM_TIME_ENSURE = """
 
 _DDL_DIM_ACCOUNT_ENSURE = """
     CREATE TABLE IF NOT EXISTS DimAccount (
-        account_id      INTEGER NOT NULL PRIMARY KEY,
+        account_int     INTEGER NOT NULL PRIMARY KEY,
         id_account      TEXT    NOT NULL UNIQUE,
         company         TEXT,
         account_type    TEXT,
@@ -162,9 +163,10 @@ _DDL_DIM_ACCOUNT_ENSURE = """
 
 _DDL_DIM_STATEMENT_ENSURE = """
     CREATE TABLE IF NOT EXISTS DimStatement (
-        statement_id    INTEGER NOT NULL PRIMARY KEY,
+        statement_int   INTEGER NOT NULL PRIMARY KEY,
         id_statement    TEXT    NOT NULL UNIQUE,
-        account_id      INTEGER NOT NULL REFERENCES DimAccount(account_id),
+        account_int     INTEGER NOT NULL REFERENCES DimAccount(account_int),
+        id_account      TEXT    NOT NULL,
         id_batch        TEXT,
         company         TEXT,
         account_type    TEXT,
@@ -185,51 +187,51 @@ _DDL_DIM_STATEMENT_ENSURE = """
 
 _DDL_FACT_TRANSACTION_ENSURE = """
     CREATE TABLE IF NOT EXISTS FactTransaction (
-        transaction_id          INTEGER NOT NULL PRIMARY KEY,
-        id_transaction          TEXT    NOT NULL UNIQUE,
-        statement_id            INTEGER NOT NULL REFERENCES DimStatement(statement_id),
-        account_id              INTEGER NOT NULL REFERENCES DimAccount(account_id),
-        time_id                 INTEGER NOT NULL REFERENCES DimTime(time_id),
-        id_date                 TEXT    NOT NULL,
-        id_account              TEXT    NOT NULL,
-        id_statement            TEXT    NOT NULL,
-        transaction_number      INTEGER,
+        transaction_int             INTEGER NOT NULL PRIMARY KEY,
+        id_transaction              TEXT    NOT NULL UNIQUE,
+        statement_int               INTEGER NOT NULL REFERENCES DimStatement(statement_int),
+        account_int                 INTEGER NOT NULL REFERENCES DimAccount(account_int),
+        date_int                    INTEGER NOT NULL REFERENCES DimDate(date_int),
+        id_date                     TEXT    NOT NULL,
+        id_account                  TEXT    NOT NULL,
+        id_statement                TEXT    NOT NULL,
+        transaction_number          INTEGER,
         transaction_credit_or_debit TEXT,
-        transaction_type        TEXT,
-        transaction_type_cd     TEXT,
-        transaction_desc        TEXT,
-        opening_balance         REAL,
-        value_in                REAL,
-        value_out               REAL,
-        value                   REAL
+        transaction_type            TEXT,
+        transaction_type_cd         TEXT,
+        transaction_desc            TEXT,
+        opening_balance             REAL,
+        value_in                    REAL,
+        value_out                   REAL,
+        value                       REAL
     )
 """
 
 _DDL_FACT_BALANCE_ENSURE = """
     CREATE TABLE IF NOT EXISTS FactBalance (
-        time_id          INTEGER NOT NULL REFERENCES DimTime(time_id),
-        account_id       INTEGER NOT NULL REFERENCES DimAccount(account_id),
+        date_int         INTEGER NOT NULL REFERENCES DimDate(date_int),
+        account_int      INTEGER NOT NULL REFERENCES DimAccount(account_int),
         id_date          TEXT    NOT NULL,
         id_account       TEXT    NOT NULL,
         opening_balance  REAL,
         closing_balance  REAL,
         movement         REAL    NOT NULL DEFAULT 0,
         outside_date     INTEGER NOT NULL DEFAULT 0,
-        PRIMARY KEY (time_id, account_id)
+        PRIMARY KEY (date_int, account_int)
     )
 """
 
 # Indexes that belong to the mart tables.  All use IF NOT EXISTS so running
 # _ensure_mart_structure() on an already-populated database is a no-op.
 _MART_INDEXES: list[str] = [
-    "CREATE INDEX IF NOT EXISTS idx_dt_id_date     ON DimTime (id_date)",
+    "CREATE INDEX IF NOT EXISTS idx_dd_id_date      ON DimDate (id_date)",
     "CREATE INDEX IF NOT EXISTS idx_ds_id_statement ON DimStatement (id_statement)",
-    "CREATE INDEX IF NOT EXISTS idx_ds_account_id   ON DimStatement (account_id)",
-    "CREATE INDEX IF NOT EXISTS idx_ft_account_date ON FactTransaction (account_id, time_id)",
-    "CREATE INDEX IF NOT EXISTS idx_ft_time_id      ON FactTransaction (time_id)",
-    "CREATE INDEX IF NOT EXISTS idx_ft_statement_id ON FactTransaction (statement_id)",
-    "CREATE INDEX IF NOT EXISTS idx_fb_account_date ON FactBalance (account_id, time_id)",
-    "CREATE INDEX IF NOT EXISTS idx_fb_time_id      ON FactBalance (time_id)",
+    "CREATE INDEX IF NOT EXISTS idx_ds_account_int  ON DimStatement (account_int)",
+    "CREATE INDEX IF NOT EXISTS idx_ft_account_date ON FactTransaction (account_int, date_int)",
+    "CREATE INDEX IF NOT EXISTS idx_ft_date_int     ON FactTransaction (date_int)",
+    "CREATE INDEX IF NOT EXISTS idx_ft_statement_int ON FactTransaction (statement_int)",
+    "CREATE INDEX IF NOT EXISTS idx_fb_account_date ON FactBalance (account_int, date_int)",
+    "CREATE INDEX IF NOT EXISTS idx_fb_date_int     ON FactBalance (date_int)",
 ]
 
 
@@ -240,7 +242,7 @@ _MART_INDEXES: list[str] = [
 
 def _drop_mart_objects(conn: sqlite3.Connection) -> None:
     """Drop all mart tables/views (both old view and new table forms)."""
-    for name in ("FactBalance", "FactTransaction", "DimStatement", "DimAccount", "DimTime"):
+    for name in ("FactBalance", "FactTransaction", "DimStatement", "DimAccount", "DimDate"):
         row = conn.execute("SELECT type FROM sqlite_master WHERE name = ?", (name,)).fetchone()
         if row is not None:
             kw = "VIEW" if row[0] == "view" else "TABLE"
@@ -265,7 +267,7 @@ def _ensure_mart_structure(conn: sqlite3.Connection) -> None:
         conn: Open SQLite connection with write access.
     """
     for ddl in (
-        _DDL_DIM_TIME_ENSURE,
+        _DDL_DIM_DATE_ENSURE,
         _DDL_DIM_ACCOUNT_ENSURE,
         _DDL_DIM_STATEMENT_ENSURE,
         _DDL_FACT_TRANSACTION_ENSURE,
@@ -281,13 +283,13 @@ def _ensure_mart_structure(conn: sqlite3.Connection) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_dim_time(conn: sqlite3.Connection, verbose: bool) -> float:
+def _build_dim_date(conn: sqlite3.Connection, verbose: bool) -> float:
     t0 = time.monotonic()
 
-    conn.execute(_DDL_DIM_TIME)
+    conn.execute(_DDL_DIM_DATE)
     conn.execute("""
-        INSERT INTO DimTime (
-            time_id, id_date, date_local_format, date_integer,
+        INSERT INTO DimDate (
+            date_int, id_date, date_local_format, date_integer,
             year, year_short, quarter, quarter_name,
             month_number, month_number_padded, month_name, month_abbrv,
             period, week, year_week,
@@ -311,7 +313,7 @@ def _build_dim_time(conn: sqlite3.Connection, verbose: bool) -> float:
             WHERE id_date < date(max_date)
         )
         SELECT
-            ROW_NUMBER() OVER (ORDER BY id_date)                            AS time_id,
+            ROW_NUMBER() OVER (ORDER BY id_date)                            AS date_int,
             id_date,
             -- %x / %y / %B / %b / %A / %a are not supported by SQLite's strftime;
             -- they return NULL.  Use CASE expressions and arithmetic instead.
@@ -320,7 +322,7 @@ def _build_dim_time(conn: sqlite3.Connection, verbose: bool) -> float:
             CAST(strftime('%Y', id_date) AS INTEGER)                        AS year,
             CAST(strftime('%Y', id_date) AS INTEGER) % 100                  AS year_short,
             -- NOTE: quarter/quarter_name deliberately use month number to
-            -- preserve parity with the original DimTime view behaviour.
+            -- preserve parity with the original DimDate view behaviour.
             CAST(strftime('%m', id_date) AS INTEGER)                        AS quarter,
             'Q' || CAST(strftime('%m', id_date) AS INTEGER)                 AS quarter_name,
             CAST(strftime('%m', id_date) AS INTEGER)                        AS month_number,
@@ -381,12 +383,12 @@ def _build_dim_time(conn: sqlite3.Connection, verbose: bool) -> float:
             CASE WHEN strftime('%w', id_date) NOT IN ('0', '6') THEN 1 ELSE 0 END AS is_weekday
         FROM recursive_dates
     """)
-    conn.execute("CREATE INDEX idx_dt_id_date ON DimTime (id_date)")
+    conn.execute("CREATE INDEX idx_dd_id_date ON DimDate (id_date)")
 
     elapsed = time.monotonic() - t0
-    n = conn.execute("SELECT COUNT(*) FROM DimTime").fetchone()[0]
+    n = conn.execute("SELECT COUNT(*) FROM DimDate").fetchone()[0]
     if verbose:
-        print(f"  [1/5] DimTime ({n:,} rows):          {elapsed:.2f}s")
+        print(f"  [1/5] DimDate ({n:,} rows):          {elapsed:.2f}s")
     return elapsed
 
 
@@ -395,10 +397,10 @@ def _build_dim_account(conn: sqlite3.Connection, verbose: bool) -> float:
 
     conn.execute(_DDL_DIM_ACCOUNT)
     conn.execute("""
-        INSERT INTO DimAccount (account_id, id_account, company, account_type,
+        INSERT INTO DimAccount (account_int, id_account, company, account_type,
                                 account_number, sortcode, account_holder, currency)
         SELECT
-            ROW_NUMBER() OVER (ORDER BY id_account) AS account_id,
+            ROW_NUMBER() OVER (ORDER BY id_account) AS account_int,
             id_account, company, account_type, account_number, sortcode, account_holder, currency
         FROM (
             SELECT
@@ -432,15 +434,16 @@ def _build_dim_statement(conn: sqlite3.Connection, verbose: bool) -> float:
     conn.execute(_DDL_DIM_STATEMENT)
     conn.execute("""
         INSERT INTO DimStatement (
-            statement_id, id_statement, account_id, id_batch,
+            statement_int, id_statement, account_int, id_account, id_batch,
             company, account_type, account_number, sortcode, account_holder,
             statement_date, opening_balance, payments_in, payments_out,
             closing_balance, statement_type, currency, filename, batch_time
         )
         SELECT
-            ROW_NUMBER() OVER (ORDER BY sh.ID_STATEMENT) AS statement_id,
+            ROW_NUMBER() OVER (ORDER BY sh.ID_STATEMENT) AS statement_int,
             sh.ID_STATEMENT,
-            da.account_id,
+            da.account_int,
+            sh.ID_ACCOUNT,
             bl.ID_BATCH,
             sh.STD_COMPANY,
             sh.STD_ACCOUNT,
@@ -461,7 +464,7 @@ def _build_dim_statement(conn: sqlite3.Connection, verbose: bool) -> float:
         INNER JOIN DimAccount da ON sh.ID_ACCOUNT = da.id_account
     """)
     conn.execute("CREATE INDEX idx_ds_id_statement ON DimStatement (id_statement)")
-    conn.execute("CREATE INDEX idx_ds_account_id   ON DimStatement (account_id)")
+    conn.execute("CREATE INDEX idx_ds_account_int  ON DimStatement (account_int)")
 
     elapsed = time.monotonic() - t0
     n = conn.execute("SELECT COUNT(*) FROM DimStatement").fetchone()[0]
@@ -476,19 +479,19 @@ def _build_fact_transaction(conn: sqlite3.Connection, verbose: bool) -> float:
     conn.execute(_DDL_FACT_TRANSACTION)
     conn.execute("""
         INSERT INTO FactTransaction (
-            transaction_id, id_transaction,
-            statement_id, account_id, time_id,
+            transaction_int, id_transaction,
+            statement_int, account_int, date_int,
             id_date, id_account, id_statement,
             transaction_number, transaction_credit_or_debit,
             transaction_type, transaction_type_cd, transaction_desc,
             opening_balance, value_in, value_out, value
         )
         SELECT
-            ROW_NUMBER() OVER (ORDER BY sl.ID_TRANSACTION) AS transaction_id,
+            ROW_NUMBER() OVER (ORDER BY sl.ID_TRANSACTION) AS transaction_int,
             sl.ID_TRANSACTION,
-            ds.statement_id,
-            da.account_id,
-            dt.time_id,
+            ds.statement_int,
+            da.account_int,
+            dd.date_int,
             sl.STD_TRANSACTION_DATE,
             sh.ID_ACCOUNT,
             sh.ID_STATEMENT,
@@ -505,11 +508,11 @@ def _build_fact_transaction(conn: sqlite3.Connection, verbose: bool) -> float:
         INNER JOIN statement_heads sh ON sl.ID_STATEMENT  = sh.ID_STATEMENT
         INNER JOIN DimStatement    ds ON sh.ID_STATEMENT  = ds.id_statement
         INNER JOIN DimAccount      da ON sh.ID_ACCOUNT    = da.id_account
-        INNER JOIN DimTime         dt ON sl.STD_TRANSACTION_DATE = dt.id_date
+        INNER JOIN DimDate         dd ON sl.STD_TRANSACTION_DATE = dd.id_date
     """)
-    conn.execute("CREATE INDEX idx_ft_account_date ON FactTransaction (account_id, time_id)")
-    conn.execute("CREATE INDEX idx_ft_time_id      ON FactTransaction (time_id)")
-    conn.execute("CREATE INDEX idx_ft_statement_id ON FactTransaction (statement_id)")
+    conn.execute("CREATE INDEX idx_ft_account_date ON FactTransaction (account_int, date_int)")
+    conn.execute("CREATE INDEX idx_ft_date_int      ON FactTransaction (date_int)")
+    conn.execute("CREATE INDEX idx_ft_statement_int ON FactTransaction (statement_int)")
 
     elapsed = time.monotonic() - t0
     n = conn.execute("SELECT COUNT(*) FROM FactTransaction").fetchone()[0]
@@ -523,32 +526,32 @@ def _build_fact_balance(conn: sqlite3.Connection, verbose: bool) -> float:
     Build FactBalance using the fill-group trick (no correlated subqueries,
     no IGNORE NULLS — which SQLite does not support).
 
-    The grid is built from already-materialised mart tables (DimTime, DimAccount)
+    The grid is built from already-materialised mart tables (DimDate, DimAccount)
     rather than raw source tables, which avoids re-scanning statement_heads /
     statement_lines and benefits from the indexes already built on the mart tables.
 
     Forward fill:
-        fwd_group = COUNT(non-null closing_balance) OVER (PARTITION BY account_id
-                    ORDER BY time_id ROWS UNBOUNDED PRECEDING)
-        MAX(closing_balance) OVER (PARTITION BY account_id, fwd_group) gives the
+        fwd_group = COUNT(non-null closing_balance) OVER (PARTITION BY account_int
+                    ORDER BY date_int ROWS UNBOUNDED PRECEDING)
+        MAX(closing_balance) OVER (PARTITION BY account_int, fwd_group) gives the
         last known balance carried forward — correct even for negative values
         because each group contains exactly one non-null row.
 
     Backward fill (opening_balance before the first transaction):
-        bwd_group = same but ORDER BY time_id DESC
-        MAX(closing_balance) OVER (PARTITION BY account_id, bwd_group)
+        bwd_group = same but ORDER BY date_int DESC
+        MAX(closing_balance) OVER (PARTITION BY account_int, bwd_group)
     """
     t0 = time.monotonic()
 
     # ------------------------------------------------------------------
-    # Temp 1: aggregate FactTransaction to one row per (account_id, time_id)
+    # Temp 1: aggregate FactTransaction to one row per (account_int, date_int)
     # ------------------------------------------------------------------
     conn.execute("DROP TABLE IF EXISTS _fb_agg")
     conn.execute("""
         CREATE TEMP TABLE _fb_agg AS
         SELECT
-            account_id,
-            time_id,
+            account_int,
+            date_int,
             id_date,
             id_account,
             MAX(STD_CLOSING_BALANCE_FROM_SRC)   AS closing_balance,
@@ -556,8 +559,8 @@ def _build_fact_balance(conn: sqlite3.Connection, verbose: bool) -> float:
         FROM (
             -- Pull closing_balance from statement_lines via the transaction
             SELECT
-                ft.account_id,
-                ft.time_id,
+                ft.account_int,
+                ft.date_int,
                 ft.id_date,
                 ft.id_account,
                 sl.STD_CLOSING_BALANCE              AS STD_CLOSING_BALANCE_FROM_SRC,
@@ -565,26 +568,26 @@ def _build_fact_balance(conn: sqlite3.Connection, verbose: bool) -> float:
             FROM FactTransaction ft
             INNER JOIN statement_lines sl ON ft.id_transaction = sl.ID_TRANSACTION
         )
-        GROUP BY account_id, time_id, id_date, id_account
+        GROUP BY account_int, date_int, id_date, id_account
     """)
-    conn.execute("CREATE INDEX idx_fb_agg ON _fb_agg (account_id, time_id)")
+    conn.execute("CREATE INDEX idx_fb_agg ON _fb_agg (account_int, date_int)")
 
     # ------------------------------------------------------------------
-    # Temp 2: account bookends from _fb_agg (first/last time_id per account)
+    # Temp 2: account bookends from _fb_agg (first/last date_int per account)
     # ------------------------------------------------------------------
     conn.execute("DROP TABLE IF EXISTS _fb_bk")
     conn.execute("""
         CREATE TEMP TABLE _fb_bk AS
-        SELECT account_id, MIN(time_id) AS first_tid, MAX(time_id) AS last_tid
+        SELECT account_int, MIN(date_int) AS first_did, MAX(date_int) AS last_did
         FROM _fb_agg
-        GROUP BY account_id
+        GROUP BY account_int
     """)
-    conn.execute("CREATE INDEX idx_fb_bk ON _fb_bk (account_id)")
+    conn.execute("CREATE INDEX idx_fb_bk ON _fb_bk (account_int)")
 
     # ------------------------------------------------------------------
     # Temp 3: full grid with fill groups
     #
-    # Cross-join DimTime × DimAccount (already small, indexed tables)
+    # Cross-join DimDate × DimAccount (already small, indexed tables)
     # then left-join the aggregated actuals.
     # ------------------------------------------------------------------
     conn.execute("DROP TABLE IF EXISTS _fb_grid")
@@ -592,33 +595,33 @@ def _build_fact_balance(conn: sqlite3.Connection, verbose: bool) -> float:
         CREATE TEMP TABLE _fb_grid AS
         WITH grid AS (
             SELECT
-                dt.time_id,
-                dt.id_date,
-                da.account_id,
+                dd.date_int,
+                dd.id_date,
+                da.account_int,
                 da.id_account,
-                CASE WHEN dt.time_id < bk.first_tid THEN 1 ELSE 0 END  AS pre_date,
-                CASE WHEN dt.time_id > bk.last_tid  THEN 1 ELSE 0 END  AS post_date,
+                CASE WHEN dd.date_int < bk.first_did THEN 1 ELSE 0 END  AS pre_date,
+                CASE WHEN dd.date_int > bk.last_did  THEN 1 ELSE 0 END  AS post_date,
                 ag.closing_balance,
                 COALESCE(ag.movement, 0.0)                               AS movement
-            FROM DimTime dt
+            FROM DimDate dd
             CROSS JOIN DimAccount da
-            LEFT JOIN _fb_bk bk ON da.account_id = bk.account_id
+            LEFT JOIN _fb_bk bk ON da.account_int = bk.account_int
             LEFT JOIN _fb_agg ag
-                   ON dt.time_id    = ag.time_id
-                  AND da.account_id = ag.account_id
+                   ON dd.date_int    = ag.date_int
+                  AND da.account_int = ag.account_int
         )
         SELECT
-            time_id, id_date, account_id, id_account,
+            date_int, id_date, account_int, id_account,
             pre_date, post_date, closing_balance, movement,
             COUNT(CASE WHEN closing_balance IS NOT NULL THEN 1 END)
-                OVER (PARTITION BY account_id ORDER BY time_id
+                OVER (PARTITION BY account_int ORDER BY date_int
                       ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS fwd_group,
             COUNT(CASE WHEN closing_balance IS NOT NULL THEN 1 END)
-                OVER (PARTITION BY account_id ORDER BY time_id DESC
+                OVER (PARTITION BY account_int ORDER BY date_int DESC
                       ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS bwd_group
         FROM grid
     """)
-    conn.execute("CREATE INDEX idx_fb_grid ON _fb_grid (account_id, fwd_group, bwd_group)")
+    conn.execute("CREATE INDEX idx_fb_grid ON _fb_grid (account_int, fwd_group, bwd_group)")
 
     # ------------------------------------------------------------------
     # Populate FactBalance
@@ -626,28 +629,28 @@ def _build_fact_balance(conn: sqlite3.Connection, verbose: bool) -> float:
     conn.execute(_DDL_FACT_BALANCE)
     conn.execute("""
         INSERT INTO FactBalance (
-            time_id, account_id, id_date, id_account,
+            date_int, account_int, id_date, id_account,
             opening_balance, closing_balance, movement, outside_date
         )
         SELECT
-            g.time_id,
-            g.account_id,
+            g.date_int,
+            g.account_int,
             g.id_date,
             g.id_account,
             CASE WHEN g.pre_date = 1 THEN NULL
                  ELSE MAX(g.closing_balance)
-                      OVER (PARTITION BY g.account_id, g.bwd_group)
+                      OVER (PARTITION BY g.account_int, g.bwd_group)
             END                                                              AS opening_balance,
             CASE WHEN g.pre_date = 1 THEN NULL
                  ELSE MAX(g.closing_balance)
-                      OVER (PARTITION BY g.account_id, g.fwd_group)
+                      OVER (PARTITION BY g.account_int, g.fwd_group)
             END                                                              AS closing_balance,
             g.movement,
             CASE WHEN g.pre_date = 1 OR g.post_date = 1 THEN 1 ELSE 0 END  AS outside_date
         FROM _fb_grid g
     """)
-    conn.execute("CREATE INDEX idx_fb_account_date ON FactBalance (account_id, time_id)")
-    conn.execute("CREATE INDEX idx_fb_time_id      ON FactBalance (time_id)")
+    conn.execute("CREATE INDEX idx_fb_account_date ON FactBalance (account_int, date_int)")
+    conn.execute("CREATE INDEX idx_fb_date_int      ON FactBalance (date_int)")
 
     # Cleanup temp tables
     for tbl in ("_fb_agg", "_fb_bk", "_fb_grid"):
@@ -667,7 +670,7 @@ def _build_fact_balance(conn: sqlite3.Connection, verbose: bool) -> float:
 
 def build_datamart(db_path: Path, verbose: bool = True) -> dict:
     """
-    Empty and rebuild all mart tables (DimTime, DimAccount, DimStatement,
+    Empty and rebuild all mart tables (DimDate, DimAccount, DimStatement,
     FactTransaction, FactBalance) from the raw source tables.
 
     Each mart table is a real SQLite table with an integer surrogate primary key.
@@ -690,7 +693,7 @@ def build_datamart(db_path: Path, verbose: bool = True) -> dict:
     _drop_mart_objects(conn)
 
     timings: dict[str, float] = {}
-    timings["DimTime"] = _build_dim_time(conn, verbose)
+    timings["DimDate"] = _build_dim_date(conn, verbose)
     timings["DimAccount"] = _build_dim_account(conn, verbose)
     timings["DimStatement"] = _build_dim_statement(conn, verbose)
     timings["FactTransaction"] = _build_fact_transaction(conn, verbose)

--- a/src/bank_statement_parser/data/build_datamart.sql
+++ b/src/bank_statement_parser/data/build_datamart.sql
@@ -20,22 +20,22 @@ DROP TABLE IF EXISTS FactBalance;
 DROP TABLE IF EXISTS FactTransaction;
 DROP TABLE IF EXISTS DimStatement;
 DROP TABLE IF EXISTS DimAccount;
-DROP TABLE IF EXISTS DimTime;
+DROP TABLE IF EXISTS DimDate;
 
 -- Also drop in case any of the above were previously created as VIEWs
 DROP VIEW IF EXISTS FactBalance;
 DROP VIEW IF EXISTS FactTransaction;
 DROP VIEW IF EXISTS DimStatement;
 DROP VIEW IF EXISTS DimAccount;
-DROP VIEW IF EXISTS DimTime;
+DROP VIEW IF EXISTS DimDate;
 
 
 -- ---------------------------------------------------------------------------
--- [1/5] DimTime
+-- [1/5] DimDate
 -- ---------------------------------------------------------------------------
 
-CREATE TABLE DimTime (
-    time_id              INTEGER NOT NULL PRIMARY KEY,
+CREATE TABLE DimDate (
+    date_int             INTEGER NOT NULL PRIMARY KEY,
     id_date              TEXT    NOT NULL UNIQUE,
     date_local_format    TEXT,
     date_integer         INTEGER,
@@ -62,8 +62,8 @@ CREATE TABLE DimTime (
     is_weekday              INTEGER NOT NULL DEFAULT 0
 );
 
-INSERT INTO DimTime (
-    time_id, id_date, date_local_format, date_integer,
+INSERT INTO DimDate (
+    date_int, id_date, date_local_format, date_integer,
     year, year_short, quarter, quarter_name,
     month_number, month_number_padded, month_name, month_abbrv,
     period, week, year_week,
@@ -87,14 +87,14 @@ recursive_dates AS (
     WHERE id_date < date(max_date)
 )
 SELECT
-    ROW_NUMBER() OVER (ORDER BY id_date)                            AS time_id,
+    ROW_NUMBER() OVER (ORDER BY id_date)                            AS date_int,
     id_date,
     strftime('%d/%m/%Y', id_date)                                   AS date_local_format,
     CAST(strftime('%Y%m%d', id_date) AS INTEGER)                    AS date_integer,
     CAST(strftime('%Y', id_date) AS INTEGER)                        AS year,
     CAST(strftime('%Y', id_date) AS INTEGER) % 100                  AS year_short,
     -- NOTE: quarter/quarter_name deliberately use month number to
-    -- preserve parity with the original DimTime view behaviour.
+    -- preserve parity with the original DimDate view behaviour.
     CAST(strftime('%m', id_date) AS INTEGER)                        AS quarter,
     'Q' || CAST(strftime('%m', id_date) AS INTEGER)                 AS quarter_name,
     CAST(strftime('%m', id_date) AS INTEGER)                        AS month_number,
@@ -155,7 +155,7 @@ SELECT
     CASE WHEN strftime('%w', id_date) NOT IN ('0', '6') THEN 1 ELSE 0 END AS is_weekday
 FROM recursive_dates;
 
-CREATE INDEX idx_dt_id_date ON DimTime (id_date);
+CREATE INDEX idx_dt_id_date ON DimDate (id_date);
 
 
 -- ---------------------------------------------------------------------------
@@ -163,7 +163,7 @@ CREATE INDEX idx_dt_id_date ON DimTime (id_date);
 -- ---------------------------------------------------------------------------
 
 CREATE TABLE DimAccount (
-    account_id      INTEGER NOT NULL PRIMARY KEY,
+    account_int     INTEGER NOT NULL PRIMARY KEY,
     id_account      TEXT    NOT NULL UNIQUE,
     company         TEXT,
     account_type    TEXT,
@@ -173,10 +173,10 @@ CREATE TABLE DimAccount (
     currency        TEXT
 );
 
-INSERT INTO DimAccount (account_id, id_account, company, account_type,
+INSERT INTO DimAccount (account_int, id_account, company, account_type,
                         account_number, sortcode, account_holder, currency)
 SELECT
-    ROW_NUMBER() OVER (ORDER BY id_account) AS account_id,
+    ROW_NUMBER() OVER (ORDER BY id_account) AS account_int,
     id_account, company, account_type, account_number, sortcode, account_holder, currency
 FROM (
     SELECT
@@ -202,9 +202,10 @@ WHERE rn = 1;
 -- ---------------------------------------------------------------------------
 
 CREATE TABLE DimStatement (
-    statement_id    INTEGER NOT NULL PRIMARY KEY,
+    statement_int   INTEGER NOT NULL PRIMARY KEY,
     id_statement    TEXT    NOT NULL UNIQUE,
-    account_id      INTEGER NOT NULL REFERENCES DimAccount(account_id),
+    account_int     INTEGER NOT NULL REFERENCES DimAccount(account_int),
+    id_account      TEXT    NOT NULL,
     id_batch        TEXT,
     company         TEXT,
     account_type    TEXT,
@@ -223,15 +224,16 @@ CREATE TABLE DimStatement (
 );
 
 INSERT INTO DimStatement (
-    statement_id, id_statement, account_id, id_batch,
+    statement_int, id_statement, account_int, id_account, id_batch,
     company, account_type, account_number, sortcode, account_holder,
     statement_date, opening_balance, payments_in, payments_out,
     closing_balance, statement_type, currency, filename, batch_time
 )
 SELECT
-    ROW_NUMBER() OVER (ORDER BY sh.ID_STATEMENT) AS statement_id,
+    ROW_NUMBER() OVER (ORDER BY sh.ID_STATEMENT) AS statement_int,
     sh.ID_STATEMENT,
-    da.account_id,
+    da.account_int,
+    sh.ID_ACCOUNT,
     bl.ID_BATCH,
     sh.STD_COMPANY,
     sh.STD_ACCOUNT,
@@ -252,7 +254,7 @@ INNER JOIN batch_lines bl ON sh.ID_BATCHLINE = bl.ID_BATCHLINE
 INNER JOIN DimAccount da ON sh.ID_ACCOUNT = da.id_account;
 
 CREATE INDEX idx_ds_id_statement ON DimStatement (id_statement);
-CREATE INDEX idx_ds_account_id   ON DimStatement (account_id);
+CREATE INDEX idx_ds_account_int  ON DimStatement (account_int);
 
 
 -- ---------------------------------------------------------------------------
@@ -260,11 +262,11 @@ CREATE INDEX idx_ds_account_id   ON DimStatement (account_id);
 -- ---------------------------------------------------------------------------
 
 CREATE TABLE FactTransaction (
-    transaction_id              INTEGER NOT NULL PRIMARY KEY,
+    transaction_int             INTEGER NOT NULL PRIMARY KEY,
     id_transaction              TEXT    NOT NULL UNIQUE,
-    statement_id                INTEGER NOT NULL REFERENCES DimStatement(statement_id),
-    account_id                  INTEGER NOT NULL REFERENCES DimAccount(account_id),
-    time_id                     INTEGER NOT NULL REFERENCES DimTime(time_id),
+    statement_int               INTEGER NOT NULL REFERENCES DimStatement(statement_int),
+    account_int                 INTEGER NOT NULL REFERENCES DimAccount(account_int),
+    date_int                    INTEGER NOT NULL REFERENCES DimDate(date_int),
     id_date                     TEXT    NOT NULL,
     id_account                  TEXT    NOT NULL,
     id_statement                TEXT    NOT NULL,
@@ -280,19 +282,19 @@ CREATE TABLE FactTransaction (
 );
 
 INSERT INTO FactTransaction (
-    transaction_id, id_transaction,
-    statement_id, account_id, time_id,
+    transaction_int, id_transaction,
+    statement_int, account_int, date_int,
     id_date, id_account, id_statement,
     transaction_number, transaction_credit_or_debit,
     transaction_type, transaction_type_cd, transaction_desc,
     opening_balance, value_in, value_out, value
 )
 SELECT
-    ROW_NUMBER() OVER (ORDER BY sl.ID_TRANSACTION) AS transaction_id,
+    ROW_NUMBER() OVER (ORDER BY sl.ID_TRANSACTION) AS transaction_int,
     sl.ID_TRANSACTION,
-    ds.statement_id,
-    da.account_id,
-    dt.time_id,
+    ds.statement_int,
+    da.account_int,
+    dd.date_int,
     sl.STD_TRANSACTION_DATE,
     sh.ID_ACCOUNT,
     sh.ID_STATEMENT,
@@ -309,35 +311,35 @@ FROM statement_lines sl
 INNER JOIN statement_heads sh ON sl.ID_STATEMENT  = sh.ID_STATEMENT
 INNER JOIN DimStatement    ds ON sh.ID_STATEMENT  = ds.id_statement
 INNER JOIN DimAccount      da ON sh.ID_ACCOUNT    = da.id_account
-INNER JOIN DimTime         dt ON sl.STD_TRANSACTION_DATE = dt.id_date;
+INNER JOIN DimDate         dd ON sl.STD_TRANSACTION_DATE = dd.id_date;
 
-CREATE INDEX idx_ft_account_date ON FactTransaction (account_id, time_id);
-CREATE INDEX idx_ft_time_id      ON FactTransaction (time_id);
-CREATE INDEX idx_ft_statement_id ON FactTransaction (statement_id);
+CREATE INDEX idx_ft_account_date ON FactTransaction (account_int, date_int);
+CREATE INDEX idx_ft_date_int     ON FactTransaction (date_int);
+CREATE INDEX idx_ft_statement_int ON FactTransaction (statement_int);
 
 
 -- ---------------------------------------------------------------------------
 -- [5/5] FactBalance
 --
 -- Uses the fill-group trick to forward/backward fill closing balances across
--- the full DimTime x DimAccount grid without correlated subqueries or
+-- the full DimDate x DimAccount grid without correlated subqueries or
 -- IGNORE NULLS (unsupported in SQLite).
 -- ---------------------------------------------------------------------------
 
--- Temp 1: aggregate FactTransaction to one row per (account_id, time_id)
+-- Temp 1: aggregate FactTransaction to one row per (account_int, date_int)
 DROP TABLE IF EXISTS _fb_agg;
 CREATE TEMP TABLE _fb_agg AS
 SELECT
-    account_id,
-    time_id,
+    account_int,
+    date_int,
     id_date,
     id_account,
     MAX(STD_CLOSING_BALANCE_FROM_SRC)   AS closing_balance,
     SUM(value)                           AS movement
 FROM (
     SELECT
-        ft.account_id,
-        ft.time_id,
+        ft.account_int,
+        ft.date_int,
         ft.id_date,
         ft.id_account,
         sl.STD_CLOSING_BALANCE              AS STD_CLOSING_BALANCE_FROM_SRC,
@@ -345,88 +347,88 @@ FROM (
     FROM FactTransaction ft
     INNER JOIN statement_lines sl ON ft.id_transaction = sl.ID_TRANSACTION
 )
-GROUP BY account_id, time_id, id_date, id_account;
+GROUP BY account_int, date_int, id_date, id_account;
 
-CREATE INDEX idx_fb_agg ON _fb_agg (account_id, time_id);
+CREATE INDEX idx_fb_agg ON _fb_agg (account_int, date_int);
 
--- Temp 2: account bookends (first/last time_id per account)
+-- Temp 2: account bookends (first/last date_int per account)
 DROP TABLE IF EXISTS _fb_bk;
 CREATE TEMP TABLE _fb_bk AS
-SELECT account_id, MIN(time_id) AS first_tid, MAX(time_id) AS last_tid
+SELECT account_int, MIN(date_int) AS first_did, MAX(date_int) AS last_did
 FROM _fb_agg
-GROUP BY account_id;
+GROUP BY account_int;
 
-CREATE INDEX idx_fb_bk ON _fb_bk (account_id);
+CREATE INDEX idx_fb_bk ON _fb_bk (account_int);
 
 -- Temp 3: full grid with fill groups
 DROP TABLE IF EXISTS _fb_grid;
 CREATE TEMP TABLE _fb_grid AS
 WITH grid AS (
     SELECT
-        dt.time_id,
-        dt.id_date,
-        da.account_id,
+        dd.date_int,
+        dd.id_date,
+        da.account_int,
         da.id_account,
-        CASE WHEN dt.time_id < bk.first_tid THEN 1 ELSE 0 END  AS pre_date,
-        CASE WHEN dt.time_id > bk.last_tid  THEN 1 ELSE 0 END  AS post_date,
+        CASE WHEN dd.date_int < bk.first_did THEN 1 ELSE 0 END  AS pre_date,
+        CASE WHEN dd.date_int > bk.last_did  THEN 1 ELSE 0 END  AS post_date,
         ag.closing_balance,
         COALESCE(ag.movement, 0.0)                               AS movement
-    FROM DimTime dt
+    FROM DimDate dd
     CROSS JOIN DimAccount da
-    LEFT JOIN _fb_bk bk ON da.account_id = bk.account_id
+    LEFT JOIN _fb_bk bk ON da.account_int = bk.account_int
     LEFT JOIN _fb_agg ag
-           ON dt.time_id    = ag.time_id
-          AND da.account_id = ag.account_id
+           ON dd.date_int    = ag.date_int
+          AND da.account_int = ag.account_int
 )
 SELECT
-    time_id, id_date, account_id, id_account,
+    date_int, id_date, account_int, id_account,
     pre_date, post_date, closing_balance, movement,
     COUNT(CASE WHEN closing_balance IS NOT NULL THEN 1 END)
-        OVER (PARTITION BY account_id ORDER BY time_id
+        OVER (PARTITION BY account_int ORDER BY date_int
               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS fwd_group,
     COUNT(CASE WHEN closing_balance IS NOT NULL THEN 1 END)
-        OVER (PARTITION BY account_id ORDER BY time_id DESC
+        OVER (PARTITION BY account_int ORDER BY date_int DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS bwd_group
 FROM grid;
 
-CREATE INDEX idx_fb_grid ON _fb_grid (account_id, fwd_group, bwd_group);
+CREATE INDEX idx_fb_grid ON _fb_grid (account_int, fwd_group, bwd_group);
 
 -- Populate FactBalance
 CREATE TABLE FactBalance (
-    time_id          INTEGER NOT NULL REFERENCES DimTime(time_id),
-    account_id       INTEGER NOT NULL REFERENCES DimAccount(account_id),
+    date_int         INTEGER NOT NULL REFERENCES DimDate(date_int),
+    account_int      INTEGER NOT NULL REFERENCES DimAccount(account_int),
     id_date          TEXT    NOT NULL,
     id_account       TEXT    NOT NULL,
     opening_balance  REAL,
     closing_balance  REAL,
     movement         REAL    NOT NULL DEFAULT 0,
     outside_date     INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (time_id, account_id)
+    PRIMARY KEY (date_int, account_int)
 );
 
 INSERT INTO FactBalance (
-    time_id, account_id, id_date, id_account,
+    date_int, account_int, id_date, id_account,
     opening_balance, closing_balance, movement, outside_date
 )
 SELECT
-    g.time_id,
-    g.account_id,
+    g.date_int,
+    g.account_int,
     g.id_date,
     g.id_account,
     CASE WHEN g.pre_date = 1 THEN NULL
          ELSE MAX(g.closing_balance)
-              OVER (PARTITION BY g.account_id, g.bwd_group)
+              OVER (PARTITION BY g.account_int, g.bwd_group)
     END                                                              AS opening_balance,
     CASE WHEN g.pre_date = 1 THEN NULL
          ELSE MAX(g.closing_balance)
-              OVER (PARTITION BY g.account_id, g.fwd_group)
+              OVER (PARTITION BY g.account_int, g.fwd_group)
     END                                                              AS closing_balance,
     g.movement,
     CASE WHEN g.pre_date = 1 OR g.post_date = 1 THEN 1 ELSE 0 END  AS outside_date
 FROM _fb_grid g;
 
-CREATE INDEX idx_fb_account_date ON FactBalance (account_id, time_id);
-CREATE INDEX idx_fb_time_id      ON FactBalance (time_id);
+CREATE INDEX idx_fb_account_date ON FactBalance (account_int, date_int);
+CREATE INDEX idx_fb_date_int     ON FactBalance (date_int);
 
 -- Cleanup temp tables
 DROP TABLE IF EXISTS _fb_agg;

--- a/src/bank_statement_parser/data/create_project_db_views.py
+++ b/src/bank_statement_parser/data/create_project_db_views.py
@@ -92,8 +92,8 @@ def create_views(db_path: Path):
             ft.value_out,
             ft.value
         FROM FactTransaction ft
-        INNER JOIN DimStatement ds ON ft.statement_id = ds.statement_id
-        INNER JOIN DimAccount   da ON ft.account_id   = da.account_id
+        INNER JOIN DimStatement ds ON ft.statement_int = ds.statement_int
+        INNER JOIN DimAccount   da ON ft.account_int   = da.account_int
     """)
     print("Created view: FlatTransaction")
 
@@ -107,9 +107,10 @@ def create_views(db_path: Path):
         CREATE VIEW DimStatementBatch AS
         SELECT DISTINCT
             bl.ID_BATCH          AS batch_id,
-            ds.statement_id,
+            ds.statement_int,
             ds.id_statement,
-            ds.account_id,
+            ds.account_int,
+            ds.id_account,
             ds.company,
             ds.account_type,
             ds.account_number,
@@ -138,11 +139,11 @@ def create_views(db_path: Path):
         CREATE VIEW FactTransactionBatch AS
         SELECT
             dsb.batch_id,
-            ft.transaction_id,
+            ft.transaction_int,
             ft.id_transaction,
-            ft.statement_id,
-            ft.account_id,
-            ft.time_id,
+            ft.statement_int,
+            ft.account_int,
+            ft.date_int,
             ft.id_date,
             ft.id_account,
             ft.id_statement,
@@ -156,7 +157,7 @@ def create_views(db_path: Path):
             ft.value_out,
             ft.value
         FROM FactTransaction ft
-        INNER JOIN DimStatementBatch dsb ON ft.statement_id = dsb.statement_id
+        INNER JOIN DimStatementBatch dsb ON ft.statement_int = dsb.statement_int
     """)
     print("Created view: FactTransactionBatch")
 
@@ -169,7 +170,7 @@ def create_views(db_path: Path):
         CREATE VIEW DimAccountBatch AS
         SELECT DISTINCT
             dsb.batch_id,
-            da.account_id,
+            da.account_int,
             da.id_account,
             da.company,
             da.account_type,
@@ -177,22 +178,22 @@ def create_views(db_path: Path):
             da.sortcode,
             da.account_holder
         FROM DimAccount da
-        INNER JOIN DimStatementBatch dsb ON da.account_id = dsb.account_id
+        INNER JOIN DimStatementBatch dsb ON da.account_int = dsb.account_int
     """)
     print("Created view: DimAccountBatch")
 
     # ------------------------------------------------------------------
-    # DimTimeBatch
+    # DimDateBatch
     # Calendar rows scoped to each batch's date range
     # (min transaction date → max statement date per batch_id).
     # ------------------------------------------------------------------
-    cursor.execute("DROP VIEW IF EXISTS DimTimeBatch")
+    cursor.execute("DROP VIEW IF EXISTS DimDateBatch")
     cursor.execute("""
-        CREATE VIEW DimTimeBatch AS
+        CREATE VIEW DimDateBatch AS
         SELECT
-            dt.*,
+            dd.*,
             r.batch_id
-        FROM DimTime dt
+        FROM DimDate dd
         INNER JOIN (
             SELECT
                 ftb.batch_id,
@@ -200,12 +201,12 @@ def create_views(db_path: Path):
                 MAX(dsb.statement_date) AS max_date
             FROM FactTransactionBatch ftb
             INNER JOIN DimStatementBatch dsb
-                   ON ftb.statement_id = dsb.statement_id
-                  AND ftb.batch_id     = dsb.batch_id
+                   ON ftb.statement_int = dsb.statement_int
+                  AND ftb.batch_id      = dsb.batch_id
             GROUP BY ftb.batch_id
-        ) r ON dt.id_date BETWEEN r.min_date AND r.max_date
+        ) r ON dd.id_date BETWEEN r.min_date AND r.max_date
     """)
-    print("Created view: DimTimeBatch")
+    print("Created view: DimDateBatch")
 
     # ------------------------------------------------------------------
     # FactBalanceBatch
@@ -218,8 +219,8 @@ def create_views(db_path: Path):
         CREATE VIEW FactBalanceBatch AS
         SELECT
             dab.batch_id,
-            fb.time_id,
-            fb.account_id,
+            fb.date_int,
+            fb.account_int,
             fb.id_date,
             fb.id_account,
             fb.opening_balance,
@@ -227,9 +228,9 @@ def create_views(db_path: Path):
             fb.movement,
             fb.outside_date
         FROM FactBalance fb
-        INNER JOIN DimAccountBatch dab ON fb.account_id = dab.account_id
-        INNER JOIN DimTimeBatch    dtb ON fb.time_id    = dtb.time_id
-                                     AND dab.batch_id   = dtb.batch_id
+        INNER JOIN DimAccountBatch dab ON fb.account_int = dab.account_int
+        INNER JOIN DimDateBatch    ddb ON fb.date_int    = ddb.date_int
+                                     AND dab.batch_id   = ddb.batch_id
     """)
     print("Created view: FactBalanceBatch")
 
@@ -259,10 +260,10 @@ def create_views(db_path: Path):
             ftb.value_out,
             ftb.value
         FROM FactTransactionBatch ftb
-        INNER JOIN DimStatementBatch dsb ON ftb.statement_id = dsb.statement_id
-                                        AND ftb.batch_id     = dsb.batch_id
-        INNER JOIN DimAccountBatch   dab ON ftb.account_id   = dab.account_id
-                                        AND ftb.batch_id     = dab.batch_id
+        INNER JOIN DimStatementBatch dsb ON ftb.statement_int = dsb.statement_int
+                                        AND ftb.batch_id      = dsb.batch_id
+        INNER JOIN DimAccountBatch   dab ON ftb.account_int   = dab.account_int
+                                        AND ftb.batch_id      = dab.batch_id
     """)
     print("Created view: FlatTransactionBatch")
 

--- a/src/bank_statement_parser/modules/export_spec.py
+++ b/src/bank_statement_parser/modules/export_spec.py
@@ -51,7 +51,7 @@ _ALLOWED_TABLES: frozenset[str] = frozenset(
         "FactBalance",
         "DimStatement",
         "DimAccount",
-        "DimTime",
+        "DimDate",
         "GapReport",
     }
 )
@@ -268,8 +268,8 @@ def _build_frame(
             f" SUBSTR(ft2.transaction_desc, 1, 25) AS short_desc,"
             f" ft2.value_in, ft2.value_out, ft2.value{id_statement_col}"
             f" FROM FactTransaction ft2"
-            f" INNER JOIN DimStatement ds ON ft2.statement_id = ds.statement_id"
-            f" INNER JOIN DimAccount da ON ft2.account_id = da.account_id"
+            f" INNER JOIN DimStatement ds ON ft2.statement_int = ds.statement_int"
+            f" INNER JOIN DimAccount da ON ft2.account_int = da.account_int"
         )
         where_clauses.append("da.id_account = ?")
     else:

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -406,7 +406,7 @@ class DimTime:
     def __init__(self, project_path: Path | None = None, batch_id: str | None = None) -> None:
         paths = ProjectPaths.resolve(project_path)
         _require_db(paths)
-        self.all = _read_data_filtered(paths.project_db, "DimTime", "DimTimeBatch", batch_id)
+        self.all = _read_data_filtered(paths.project_db, "DimDate", "DimDateBatch", batch_id)
 
 
 class DimStatement:

--- a/tests/test_datamart.py
+++ b/tests/test_datamart.py
@@ -1,5 +1,5 @@
 """
-Tests that validate the data mart (DimTime, DimAccount, DimStatement,
+Tests that validate the data mart (DimDate, DimAccount, DimStatement,
 FactTransaction, FactBalance) against the raw source tables.
 
 A session-scoped fixture creates a fresh SQLite database in the tests/
@@ -57,29 +57,29 @@ def _scalar(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# DimTime
+# DimDate
 # ---------------------------------------------------------------------------
 
 
 class TestDimTime:
     def test_row_count_matches_date_range(self, conn):
-        """DimTime has exactly one row per calendar day from the earliest
+        """DimDate has exactly one row per calendar day from the earliest
         transaction date to the latest statement date (inclusive)."""
         min_date_str = _scalar(conn, "SELECT MIN(STD_TRANSACTION_DATE) FROM statement_lines")
         max_date_str = _scalar(conn, "SELECT MAX(STD_STATEMENT_DATE) FROM statement_heads")
         expected = (datetime.date.fromisoformat(max_date_str) - datetime.date.fromisoformat(min_date_str)).days + 1
-        actual = _scalar(conn, "SELECT COUNT(*) FROM DimTime")
+        actual = _scalar(conn, "SELECT COUNT(*) FROM DimDate")
         assert actual == expected
 
     def test_date_spine_is_contiguous(self, conn):
-        """There are no missing days in the DimTime date spine."""
+        """There are no missing days in the DimDate date spine."""
         gaps = _scalar(
             conn,
             """
             SELECT COUNT(*) FROM (
                 SELECT id_date,
                        LAG(id_date) OVER (ORDER BY id_date) AS prev_date
-                FROM DimTime
+                FROM DimDate
             )
             WHERE prev_date IS NOT NULL
             AND julianday(id_date) - julianday(prev_date) != 1
@@ -89,29 +89,29 @@ class TestDimTime:
 
     def test_min_date_equals_earliest_transaction(self, conn):
         raw_min = _scalar(conn, "SELECT MIN(STD_TRANSACTION_DATE) FROM statement_lines")
-        mart_min = _scalar(conn, "SELECT MIN(id_date) FROM DimTime")
+        mart_min = _scalar(conn, "SELECT MIN(id_date) FROM DimDate")
         assert mart_min == raw_min
 
     def test_max_date_equals_latest_statement(self, conn):
         raw_max = _scalar(conn, "SELECT MAX(STD_STATEMENT_DATE) FROM statement_heads")
-        mart_max = _scalar(conn, "SELECT MAX(id_date) FROM DimTime")
+        mart_max = _scalar(conn, "SELECT MAX(id_date) FROM DimDate")
         assert mart_max == raw_max
 
     def test_no_null_columns(self, conn):
-        """Every column in DimTime is fully populated — no NULLs anywhere."""
-        cols = [c[1] for c in conn.execute("PRAGMA table_info(DimTime)").fetchall()]
-        null_counts = {col: _scalar(conn, f"SELECT COUNT(*) FROM DimTime WHERE {col} IS NULL") for col in cols}
+        """Every column in DimDate is fully populated — no NULLs anywhere."""
+        cols = [c[1] for c in conn.execute("PRAGMA table_info(DimDate)").fetchall()]
+        null_counts = {col: _scalar(conn, f"SELECT COUNT(*) FROM DimDate WHERE {col} IS NULL") for col in cols}
         nulls = {col: n for col, n in null_counts.items() if n > 0}
         assert nulls == {}, f"Columns with NULLs: {nulls}"
 
     def test_time_id_is_unique(self, conn):
-        total = _scalar(conn, "SELECT COUNT(*)          FROM DimTime")
-        distinct = _scalar(conn, "SELECT COUNT(DISTINCT time_id) FROM DimTime")
+        total = _scalar(conn, "SELECT COUNT(*)           FROM DimDate")
+        distinct = _scalar(conn, "SELECT COUNT(DISTINCT date_int) FROM DimDate")
         assert total == distinct
 
     def test_id_date_is_unique(self, conn):
-        total = _scalar(conn, "SELECT COUNT(*)           FROM DimTime")
-        distinct = _scalar(conn, "SELECT COUNT(DISTINCT id_date) FROM DimTime")
+        total = _scalar(conn, "SELECT COUNT(*)           FROM DimDate")
+        distinct = _scalar(conn, "SELECT COUNT(DISTINCT id_date) FROM DimDate")
         assert total == distinct
 
     def test_year_derived_correctly(self, conn):
@@ -119,7 +119,7 @@ class TestDimTime:
         mismatches = _scalar(
             conn,
             """
-            SELECT COUNT(*) FROM DimTime
+            SELECT COUNT(*) FROM DimDate
             WHERE year != CAST(strftime('%Y', id_date) AS INTEGER)
         """,
         )
@@ -130,7 +130,7 @@ class TestDimTime:
         mismatches = _scalar(
             conn,
             """
-            SELECT COUNT(*) FROM DimTime
+            SELECT COUNT(*) FROM DimDate
             WHERE year_short != year % 100
         """,
         )
@@ -140,7 +140,7 @@ class TestDimTime:
         mismatches = _scalar(
             conn,
             """
-            SELECT COUNT(*) FROM DimTime
+            SELECT COUNT(*) FROM DimDate
             WHERE month_number != CAST(strftime('%m', id_date) AS INTEGER)
         """,
         )
@@ -162,7 +162,7 @@ class TestDimTime:
             11: "November",
             12: "December",
         }
-        rows = conn.execute("SELECT DISTINCT month_number, month_name FROM DimTime ORDER BY month_number").fetchall()
+        rows = conn.execute("SELECT DISTINCT month_number, month_name FROM DimDate ORDER BY month_number").fetchall()
         actual = {r[0]: r[1] for r in rows}
         for num, name in expected.items():
             if num in actual:
@@ -183,7 +183,7 @@ class TestDimTime:
             11: "Nov",
             12: "Dec",
         }
-        rows = conn.execute("SELECT DISTINCT month_number, month_abbrv FROM DimTime ORDER BY month_number").fetchall()
+        rows = conn.execute("SELECT DISTINCT month_number, month_abbrv FROM DimDate ORDER BY month_number").fetchall()
         actual = {r[0]: r[1] for r in rows}
         for num, abbrv in expected.items():
             if num in actual:
@@ -195,7 +195,7 @@ class TestDimTime:
         expected = {0: "Sunday", 1: "Monday", 2: "Tuesday", 3: "Wednesday", 4: "Thursday", 5: "Friday", 6: "Saturday"}
         rows = conn.execute("""
             SELECT DISTINCT CAST(strftime('%w', id_date) AS INTEGER) AS dow, weekday
-            FROM DimTime ORDER BY dow
+            FROM DimDate ORDER BY dow
         """).fetchall()
         for dow, name in rows:
             assert name == expected[dow], f"dow {dow}: expected {expected[dow]!r}, got {name!r}"
@@ -204,7 +204,7 @@ class TestDimTime:
         mismatches = _scalar(
             conn,
             """
-            SELECT COUNT(*) FROM DimTime
+            SELECT COUNT(*) FROM DimDate
             WHERE weekday_abbrv != SUBSTR(weekday, 1, 3)
         """,
         )
@@ -212,8 +212,8 @@ class TestDimTime:
 
     def test_day_of_week_is_one_indexed(self, conn):
         """day_of_week runs 1–7 (Sunday=1 through Saturday=7)."""
-        min_dow = _scalar(conn, "SELECT MIN(day_of_week) FROM DimTime")
-        max_dow = _scalar(conn, "SELECT MAX(day_of_week) FROM DimTime")
+        min_dow = _scalar(conn, "SELECT MIN(day_of_week) FROM DimDate")
+        max_dow = _scalar(conn, "SELECT MAX(day_of_week) FROM DimDate")
         assert min_dow == 1
         assert max_dow == 7
 
@@ -222,7 +222,7 @@ class TestDimTime:
         mismatches = _scalar(
             conn,
             """
-            SELECT COUNT(*) FROM DimTime
+            SELECT COUNT(*) FROM DimDate
             WHERE is_weekday != CASE WHEN day_of_week BETWEEN 2 AND 6 THEN 1 ELSE 0 END
         """,
         )
@@ -233,7 +233,7 @@ class TestDimTime:
         mismatches = _scalar(
             conn,
             """
-            SELECT COUNT(*) FROM DimTime
+            SELECT COUNT(*) FROM DimDate
             WHERE is_last_day_of_month != CASE
                 WHEN day_of_month =
                      CAST(strftime('%d', date(id_date, 'start of month', '+1 month', '-1 day')) AS INTEGER)
@@ -257,8 +257,8 @@ class TestDimAccount:
         assert mart == raw
 
     def test_account_id_is_unique(self, conn):
-        total = _scalar(conn, "SELECT COUNT(*)               FROM DimAccount")
-        distinct = _scalar(conn, "SELECT COUNT(DISTINCT account_id) FROM DimAccount")
+        total = _scalar(conn, "SELECT COUNT(*)                FROM DimAccount")
+        distinct = _scalar(conn, "SELECT COUNT(DISTINCT account_int) FROM DimAccount")
         assert total == distinct
 
     def test_id_account_is_unique(self, conn):
@@ -295,7 +295,7 @@ class TestDimAccount:
             conn.execute("""
             SELECT da.id_account, COUNT(*)
             FROM DimStatement ds
-            JOIN DimAccount da ON ds.account_id = da.account_id
+            JOIN DimAccount da ON ds.account_int = da.account_int
             GROUP BY da.id_account
         """).fetchall()
         )
@@ -314,8 +314,8 @@ class TestDimStatement:
         assert mart == raw
 
     def test_statement_id_is_unique(self, conn):
-        total = _scalar(conn, "SELECT COUNT(*)                  FROM DimStatement")
-        distinct = _scalar(conn, "SELECT COUNT(DISTINCT statement_id) FROM DimStatement")
+        total = _scalar(conn, "SELECT COUNT(*)                    FROM DimStatement")
+        distinct = _scalar(conn, "SELECT COUNT(DISTINCT statement_int) FROM DimStatement")
         assert total == distinct
 
     def test_id_statement_is_unique(self, conn):
@@ -365,7 +365,7 @@ class TestDimStatement:
             conn.execute("""
             SELECT da.id_account, ROUND(SUM(ds.payments_in), 4)
             FROM DimStatement ds
-            JOIN DimAccount da ON ds.account_id = da.account_id
+            JOIN DimAccount da ON ds.account_int = da.account_int
             GROUP BY da.id_account
         """).fetchall()
         )
@@ -378,8 +378,8 @@ class TestDimStatement:
             conn,
             """
             SELECT COUNT(*) FROM DimStatement ds
-            LEFT JOIN DimAccount da ON ds.account_id = da.account_id
-            WHERE da.account_id IS NULL
+            LEFT JOIN DimAccount da ON ds.account_int = da.account_int
+            WHERE da.account_int IS NULL
         """,
         )
         assert orphans == 0
@@ -397,8 +397,8 @@ class TestFactTransaction:
         assert mart == raw
 
     def test_transaction_id_is_unique(self, conn):
-        total = _scalar(conn, "SELECT COUNT(*)                     FROM FactTransaction")
-        distinct = _scalar(conn, "SELECT COUNT(DISTINCT transaction_id) FROM FactTransaction")
+        total = _scalar(conn, "SELECT COUNT(*)                       FROM FactTransaction")
+        distinct = _scalar(conn, "SELECT COUNT(DISTINCT transaction_int) FROM FactTransaction")
         assert total == distinct
 
     def test_id_transaction_covers_all_raw(self, conn):
@@ -442,7 +442,7 @@ class TestFactTransaction:
             conn.execute("""
             SELECT da.id_account, ROUND(SUM(ft.value_in), 4)
             FROM FactTransaction ft
-            JOIN DimAccount da ON ft.account_id = da.account_id
+            JOIN DimAccount da ON ft.account_int = da.account_int
             GROUP BY da.id_account
         """).fetchall()
         )
@@ -463,7 +463,7 @@ class TestFactTransaction:
             conn.execute("""
             SELECT da.id_account, ROUND(SUM(ft.value_out), 4)
             FROM FactTransaction ft
-            JOIN DimAccount da ON ft.account_id = da.account_id
+            JOIN DimAccount da ON ft.account_int = da.account_int
             GROUP BY da.id_account
         """).fetchall()
         )
@@ -484,7 +484,7 @@ class TestFactTransaction:
             conn.execute("""
             SELECT da.id_account, COUNT(*)
             FROM FactTransaction ft
-            JOIN DimAccount da ON ft.account_id = da.account_id
+            JOIN DimAccount da ON ft.account_int = da.account_int
             GROUP BY da.id_account
         """).fetchall()
         )
@@ -502,10 +502,10 @@ class TestFactTransaction:
         )
         mart = dict(
             conn.execute("""
-            SELECT dt.period, COUNT(*)
+            SELECT dd.period, COUNT(*)
             FROM FactTransaction ft
-            JOIN DimTime dt ON ft.time_id = dt.time_id
-            GROUP BY dt.period
+            JOIN DimDate dd ON ft.date_int = dd.date_int
+            GROUP BY dd.period
         """).fetchall()
         )
         assert mart == raw
@@ -515,8 +515,8 @@ class TestFactTransaction:
             conn,
             """
             SELECT COUNT(*) FROM FactTransaction ft
-            LEFT JOIN DimAccount da ON ft.account_id = da.account_id
-            WHERE da.account_id IS NULL
+            LEFT JOIN DimAccount da ON ft.account_int = da.account_int
+            WHERE da.account_int IS NULL
         """,
         )
         assert orphans == 0
@@ -526,8 +526,8 @@ class TestFactTransaction:
             conn,
             """
             SELECT COUNT(*) FROM FactTransaction ft
-            LEFT JOIN DimTime dt ON ft.time_id = dt.time_id
-            WHERE dt.time_id IS NULL
+            LEFT JOIN DimDate dd ON ft.date_int = dd.date_int
+            WHERE dd.date_int IS NULL
         """,
         )
         assert orphans == 0
@@ -537,20 +537,20 @@ class TestFactTransaction:
             conn,
             """
             SELECT COUNT(*) FROM FactTransaction ft
-            LEFT JOIN DimStatement ds ON ft.statement_id = ds.statement_id
-            WHERE ds.statement_id IS NULL
+            LEFT JOIN DimStatement ds ON ft.statement_int = ds.statement_int
+            WHERE ds.statement_int IS NULL
         """,
         )
         assert orphans == 0
 
     def test_id_date_consistent_with_time_id(self, conn):
-        """id_date on FactTransaction matches the id_date of the joined DimTime row."""
+        """id_date on FactTransaction matches the id_date of the joined DimDate row."""
         mismatches = _scalar(
             conn,
             """
             SELECT COUNT(*) FROM FactTransaction ft
-            JOIN DimTime dt ON ft.time_id = dt.time_id
-            WHERE ft.id_date != dt.id_date
+            JOIN DimDate dd ON ft.date_int = dd.date_int
+            WHERE ft.id_date != dd.id_date
         """,
         )
         assert mismatches == 0
@@ -565,7 +565,7 @@ class TestFactBalance:
     def test_row_count_equals_accounts_times_date_spine(self, conn):
         """FactBalance has exactly one row per (account, day) across the full spine."""
         n_accounts = _scalar(conn, "SELECT COUNT(*) FROM DimAccount")
-        n_days = _scalar(conn, "SELECT COUNT(*) FROM DimTime")
+        n_days = _scalar(conn, "SELECT COUNT(*) FROM DimDate")
         expected = n_accounts * n_days
         actual = _scalar(conn, "SELECT COUNT(*) FROM FactBalance")
         assert actual == expected
@@ -575,9 +575,9 @@ class TestFactBalance:
             conn,
             """
             SELECT COUNT(*) FROM (
-                SELECT time_id, account_id, COUNT(*) AS c
+                SELECT date_int, account_int, COUNT(*) AS c
                 FROM FactBalance
-                GROUP BY time_id, account_id
+                GROUP BY date_int, account_int
                 HAVING c > 1
             )
         """,
@@ -589,8 +589,8 @@ class TestFactBalance:
             conn,
             """
             SELECT COUNT(*) FROM FactBalance fb
-            LEFT JOIN DimAccount da ON fb.account_id = da.account_id
-            WHERE da.account_id IS NULL
+            LEFT JOIN DimAccount da ON fb.account_int = da.account_int
+            WHERE da.account_int IS NULL
         """,
         )
         assert orphans == 0
@@ -600,8 +600,8 @@ class TestFactBalance:
             conn,
             """
             SELECT COUNT(*) FROM FactBalance fb
-            LEFT JOIN DimTime dt ON fb.time_id = dt.time_id
-            WHERE dt.time_id IS NULL
+            LEFT JOIN DimDate dd ON fb.date_int = dd.date_int
+            WHERE dd.date_int IS NULL
         """,
         )
         assert orphans == 0
@@ -658,9 +658,9 @@ class TestFactBalance:
                 """
                 SELECT fb.closing_balance
                 FROM FactBalance fb
-                JOIN DimAccount da ON fb.account_id = da.account_id
-                JOIN DimTime    dt ON fb.time_id    = dt.time_id
-                WHERE da.id_account = ? AND dt.id_date = ?
+                JOIN DimAccount da ON fb.account_int = da.account_int
+                JOIN DimDate    dd ON fb.date_int    = dd.date_int
+                WHERE da.id_account = ? AND dd.id_date = ?
             """,
                 (id_account, last_date),
             )
@@ -694,9 +694,9 @@ class TestFactBalance:
                 """
                 SELECT fb.closing_balance
                 FROM FactBalance fb
-                JOIN DimAccount da ON fb.account_id = da.account_id
-                JOIN DimTime    dt ON fb.time_id    = dt.time_id
-                WHERE da.id_account = ? AND dt.id_date = ?
+                JOIN DimAccount da ON fb.account_int = da.account_int
+                JOIN DimDate    dd ON fb.date_int    = dd.date_int
+                WHERE da.id_account = ? AND dd.id_date = ?
             """,
                 (id_account, first_date),
             )
@@ -714,8 +714,8 @@ class TestFactBalance:
             WHERE fb.movement != 0
             AND NOT EXISTS (
                 SELECT 1 FROM FactTransaction ft
-                WHERE ft.account_id = fb.account_id
-                AND ft.time_id = fb.time_id
+                WHERE ft.account_int = fb.account_int
+                AND ft.date_int = fb.date_int
             )
         """,
         )
@@ -728,16 +728,16 @@ class TestFactBalance:
             conn,
             """
             WITH bookends AS (
-                SELECT account_id,
-                       MIN(time_id) AS first_tid,
-                       MAX(time_id) AS last_tid
+                SELECT account_int,
+                       MIN(date_int) AS first_did,
+                       MAX(date_int) AS last_did
                 FROM FactTransaction
-                GROUP BY account_id
+                GROUP BY account_int
             )
             SELECT COUNT(*) FROM FactBalance fb
-            JOIN bookends bk ON fb.account_id = bk.account_id
+            JOIN bookends bk ON fb.account_int = bk.account_int
             WHERE fb.outside_date != CASE
-                WHEN fb.time_id < bk.first_tid OR fb.time_id > bk.last_tid
+                WHEN fb.date_int < bk.first_did OR fb.date_int > bk.last_did
                 THEN 1 ELSE 0
             END
         """,
@@ -749,8 +749,8 @@ class TestFactBalance:
             conn,
             """
             SELECT COUNT(*) FROM FactBalance fb
-            JOIN DimTime dt ON fb.time_id = dt.time_id
-            WHERE fb.id_date != dt.id_date
+            JOIN DimDate dd ON fb.date_int = dd.date_int
+            WHERE fb.id_date != dd.id_date
         """,
         )
         assert mismatches == 0
@@ -760,7 +760,7 @@ class TestFactBalance:
             conn,
             """
             SELECT COUNT(*) FROM FactBalance fb
-            JOIN DimAccount da ON fb.account_id = da.account_id
+            JOIN DimAccount da ON fb.account_int = da.account_int
             WHERE fb.id_account != da.id_account
         """,
         )
@@ -774,12 +774,12 @@ class TestFactBalance:
 
 class TestSurrogateKeyConsistency:
     def test_fact_transaction_account_id_matches_dim_account(self, conn):
-        """FactTransaction.id_account matches DimAccount.id_account via account_id FK."""
+        """FactTransaction.id_account matches DimAccount.id_account via account_int FK."""
         mismatches = _scalar(
             conn,
             """
             SELECT COUNT(*) FROM FactTransaction ft
-            JOIN DimAccount da ON ft.account_id = da.account_id
+            JOIN DimAccount da ON ft.account_int = da.account_int
             WHERE ft.id_account != da.id_account
         """,
         )
@@ -790,19 +790,19 @@ class TestSurrogateKeyConsistency:
             conn,
             """
             SELECT COUNT(*) FROM FactTransaction ft
-            JOIN DimStatement ds ON ft.statement_id = ds.statement_id
+            JOIN DimStatement ds ON ft.statement_int = ds.statement_int
             WHERE ft.id_statement != ds.id_statement
         """,
         )
         assert mismatches == 0
 
     def test_dim_statement_account_id_matches_dim_account(self, conn):
-        """Every DimStatement.account_id resolves to the correct id_account."""
+        """Every DimStatement.account_int resolves to the correct id_account."""
         mismatches = _scalar(
             conn,
             """
             SELECT COUNT(*) FROM DimStatement ds
-            JOIN DimAccount da ON ds.account_id = da.account_id
+            JOIN DimAccount da ON ds.account_int = da.account_int
             JOIN statement_heads sh ON ds.id_statement = sh.ID_STATEMENT
             WHERE da.id_account != sh.ID_ACCOUNT
         """,

--- a/tests/test_export_spec.py
+++ b/tests/test_export_spec.py
@@ -62,7 +62,7 @@ def _get_flat_transaction_count(project_path: Path, account_key: str) -> int:
     paths = ProjectPaths.resolve(project_path)
     with sqlite3.connect(paths.project_db) as conn:
         row = conn.execute(
-            "SELECT COUNT(*) FROM FactTransaction ft INNER JOIN DimAccount da ON ft.account_id = da.account_id WHERE da.id_account = ?",
+            "SELECT COUNT(*) FROM FactTransaction ft INNER JOIN DimAccount da ON ft.account_int = da.account_int WHERE da.id_account = ?",
             [account_key],
         ).fetchone()
     return row[0] if row else 0
@@ -75,7 +75,7 @@ def _get_fact_transaction_value_in_sum(project_path: Path, account_key: str) -> 
         row = conn.execute(
             "SELECT COALESCE(SUM(ft.value_in), 0)"
             " FROM FactTransaction ft"
-            " INNER JOIN DimAccount da ON ft.account_id = da.account_id"
+            " INNER JOIN DimAccount da ON ft.account_int = da.account_int"
             " WHERE da.id_account = ?",
             [account_key],
         ).fetchone()
@@ -89,7 +89,7 @@ def _get_fact_transaction_value_out_sum(project_path: Path, account_key: str) ->
         row = conn.execute(
             "SELECT COALESCE(SUM(ft.value_out), 0)"
             " FROM FactTransaction ft"
-            " INNER JOIN DimAccount da ON ft.account_id = da.account_id"
+            " INNER JOIN DimAccount da ON ft.account_int = da.account_int"
             " WHERE da.id_account = ?",
             [account_key],
         ).fetchone()
@@ -103,7 +103,7 @@ def _get_statement_ids(project_path: Path, account_key: str) -> list[str]:
         rows = conn.execute(
             "SELECT ds.id_statement"
             " FROM DimStatement ds"
-            " INNER JOIN DimAccount da ON ds.account_id = da.account_id"
+            " INNER JOIN DimAccount da ON ds.account_int = da.account_int"
             " WHERE da.id_account = ?"
             " ORDER BY ds.id_statement",
             [account_key],

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -173,7 +173,7 @@ _MULTI_EXPORT_STEMS = [
 _MULTI_STEM_TO_DB_TABLE = {
     "statement_dimension": "DimStatement",
     "account_dimension": "DimAccount",
-    "calendar_dimension": "DimTime",
+    "calendar_dimension": "DimDate",
     "transaction_measures": "FactTransaction",
     "daily_account_balances": "FactBalance",
     "missing_statement_report": "GapReport",

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "uk-bank-statement-parser"
-version = "0.2.1a6"
+version = "0.2.1a7"
 source = { editable = "." }
 dependencies = [
     { name = "dacite" },


### PR DESCRIPTION
## Summary

- Renames the `DimTime` datamart table to `DimDate` (and `DimTimeBatch` view to `DimDateBatch`) for clarity
- Renames all integer surrogate key columns from the `_id` suffix to `_int` (`time_id`→`date_int`, `account_id`→`account_int`, `statement_id`→`statement_int`, `transaction_id`→`transaction_int`) to distinguish them from string natural keys
- Adds a denormalised `id_account TEXT NOT NULL` column to `DimStatement`, aligning it with the pattern already used in `FactTransaction` and `FactBalance`

## Files changed

| File | Change |
|---|---|
| `data/build_datamart.py` | Full rename applied; `id_account` population added to `DimStatement` build step |
| `data/build_datamart.sql` | Kept in sync with `.py` (authoritative at runtime) |
| `data/create_project_db_views.py` | All views updated to use new column/table names |
| `modules/export_spec.py` | `_ALLOWED_TABLES` and join conditions updated |
| `modules/reports_db.py` | `DimTime` class updated to reference `DimDate`/`DimDateBatch` |
| `tests/test_datamart.py` | All SQL queries and assertions updated |
| `tests/test_export_spec.py` | Join condition column names updated |
| `tests/test_statements.py` | `_MULTI_STEM_TO_DB_TABLE` entry updated |
| `docs/reference/python-api.md` | Regenerated via `scripts/generate_docs.py` |

## Testing

All 202 tests pass.