### PR TITLE
feat: use timestamp subfolder and statement_date in export_spec outputs

### DIFF
--- a/src/bank_statement_parser/modules/export_spec.py
+++ b/src/bank_statement_parser/modules/export_spec.py
@@ -21,7 +21,7 @@ import re
 import sqlite3
 import tomllib
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 
 import polars as pl
@@ -43,6 +43,12 @@ _KNOWN_COMPUTED: frozenset[str] = frozenset({_COMPUTED_SIGNED_AMOUNT})
 # Columns in FlatTransaction that contain dates (need format conversion)
 _DATE_COLUMNS: frozenset[str] = frozenset({"transaction_date", "statement_date"})
 
+# Column used to partition rows when split_by_statement=True
+_SPLIT_ANCHOR = "id_statement"
+
+# Column used to derive the filename stem when split_by_statement=True
+_SPLIT_DATE_ANCHOR = "statement_date"
+
 # Allowed source tables / views
 _ALLOWED_TABLES: frozenset[str] = frozenset(
     {
@@ -55,6 +61,15 @@ _ALLOWED_TABLES: frozenset[str] = frozenset(
         "GapReport",
     }
 )
+
+
+def _ts() -> str:
+    """Return the current local datetime as a compact timestamp string.
+
+    Returns:
+        Datetime formatted as ``"yyyymmddHHMMSS"``, e.g. ``"20250331143022"``.
+    """
+    return datetime.now().strftime("%Y%m%d%H%M%S")
 
 
 # ---------------------------------------------------------------------------
@@ -219,10 +234,6 @@ def _require_int(section: dict, key: str, spec_path: Path) -> int:
 # ---------------------------------------------------------------------------
 # _build_frame
 # ---------------------------------------------------------------------------
-
-# Columns needed beyond those declared in a spec when split_by_statement is True.
-# We always fetch id_statement so we can partition, then drop it from output.
-_SPLIT_ANCHOR = "id_statement"
 
 
 def _build_frame(
@@ -599,7 +610,7 @@ def export_spec(
     lf = _apply_blank_zeros(lf, loaded)
     lf = _sanitise_strings(lf, loaded)
 
-    output_dir = paths.export_specs_output(spec.stem)
+    output_dir = paths.export_specs_output(spec.stem) / _ts()
     paths.ensure_subdir_for_write(output_dir)
 
     if not loaded.split_by_statement:
@@ -620,14 +631,32 @@ def export_spec(
             written = _write_frames([(account_key, df_mapped)], output_dir, loaded)
         else:
             statement_ids = df_raw[_SPLIT_ANCHOR].unique().sort().to_list()
+
+            # Map each id_statement → YYYYMMDD from statement_date
+            sid_to_date: dict[str, str] = {}
+            for sid in statement_ids:
+                raw_date = df_raw.filter(pl.col(_SPLIT_ANCHOR) == sid)[_SPLIT_DATE_ANCHOR][0]
+                sid_to_date[sid] = str(raw_date).replace("-", "")
+
+            # Resolve duplicate dates by appending a counter (_1, _2, ...)
+            date_counts: dict[str, int] = {}
+            for d in sid_to_date.values():
+                date_counts[d] = date_counts.get(d, 0) + 1
+            date_seen: dict[str, int] = {}
+
             frames: list[tuple[str, pl.DataFrame]] = []
             for sid in statement_ids:
+                date_str = sid_to_date[sid]
+                if date_counts[date_str] > 1:
+                    date_seen[date_str] = date_seen.get(date_str, 0) + 1
+                    stem = f"{account_key}_{date_str}_{date_seen[date_str]}"
+                else:
+                    stem = f"{account_key}_{date_str}"
                 partition = df_raw.filter(pl.col(_SPLIT_ANCHOR) == sid).lazy()
                 partition = _apply_column_mapping(partition, loaded)
                 partition = _apply_date_format(partition, loaded)
                 partition = _apply_blank_zeros(partition, loaded)
                 partition = _sanitise_strings(partition, loaded)
-                stem = f"{account_key}_{sid}"
                 frames.append((stem, partition.collect()))
             written = _write_frames(frames, output_dir, loaded)
 

--- a/tests/test_export_spec.py
+++ b/tests/test_export_spec.py
@@ -111,6 +111,21 @@ def _get_statement_ids(project_path: Path, account_key: str) -> list[str]:
     return [r[0] for r in rows]
 
 
+def _get_statement_dates(project_path: Path, account_key: str) -> list[str]:
+    """Return all statement_date values for a given account as YYYYMMDD strings, sorted."""
+    paths = ProjectPaths.resolve(project_path)
+    with sqlite3.connect(paths.project_db) as conn:
+        rows = conn.execute(
+            "SELECT ds.statement_date"
+            " FROM DimStatement ds"
+            " INNER JOIN DimAccount da ON ds.account_int = da.account_int"
+            " WHERE da.id_account = ?"
+            " ORDER BY ds.statement_date",
+            [account_key],
+        ).fetchall()
+    return [r[0].replace("-", "") for r in rows]
+
+
 # ---------------------------------------------------------------------------
 # TestLoadSpec
 # ---------------------------------------------------------------------------
@@ -330,11 +345,11 @@ class TestExportSpecOutput:
         assert written[0].stat().st_size > 0
 
     def test_output_dir_is_under_export(self, good_project):
-        """Output file lives under export/<spec_stem>/ not export/specs/."""
+        """Output file lives under export/<spec_stem>/<timestamp>/ not export/specs/."""
         written = export_spec(_SPEC_3COL, account_key=_ACCOUNT_KEY, project_path=good_project.project_path)
         paths = ProjectPaths.resolve(good_project.project_path)
-        expected_dir = paths.exports / _SPEC_3COL.stem
-        assert written[0].parent == expected_dir
+        expected_base = paths.exports / _SPEC_3COL.stem
+        assert written[0].parent.parent == expected_base
 
     def test_output_filename_matches_account_key(self, good_project):
         """Single-file output is named <account_key>.csv."""
@@ -552,15 +567,15 @@ class TestExportSpecFiltering:
         assert len(written) == len(statement_ids), f"Expected {len(statement_ids)} files, got {len(written)}"
 
     def test_split_by_statement_filenames(self, good_project):
-        """Each split file is named <account_key>_<id_statement>.csv."""
-        statement_ids = _get_statement_ids(good_project.project_path, _ACCOUNT_KEY)
+        """Each split file is named <account_key>_<YYYYMMDD>.csv."""
+        statement_dates = _get_statement_dates(good_project.project_path, _ACCOUNT_KEY)
         written = export_spec(
             _SPEC_3COL,
             account_key=_ACCOUNT_KEY,
             project_path=good_project.project_path,
             split_by_statement=True,
         )
-        expected_stems = {f"{_ACCOUNT_KEY}_{sid}" for sid in statement_ids}
+        expected_stems = {f"{_ACCOUNT_KEY}_{d}" for d in statement_dates}
         actual_stems = {p.stem for p in written}
         assert actual_stems == expected_stems, f"Stem mismatch.\nExpected: {sorted(expected_stems)}\nActual:   {sorted(actual_stems)}"
 


### PR DESCRIPTION
## Summary

- All `export_spec()` calls now write into `export/<spec_stem>/<yyyymmddHHMMSS>/` — each invocation gets its own timestamped subfolder, consistent with the pattern used by `reports_db.py` for default project exports.
- `split_by_statement` filenames now use `statement_date` (formatted `YYYYMMDD`) instead of the SHA512 `id_statement` hash, making split files human-readable (e.g. `HSBC_UK_CUR_12345678_20240131.csv`). Duplicate dates within the same account are disambiguated with a counter suffix (`_1`, `_2`, ...).

## Changes

- `export_spec.py`: added `datetime` import, `_SPLIT_DATE_ANCHOR` constant, `_ts()` helper, timestamp subfolder in `output_dir`, and updated split stem logic.
- `test_export_spec.py`: updated `test_output_dir_is_under_export` and `test_split_by_statement_filenames`; added `_get_statement_dates()` helper.

## Tests

All 39 tests in `test_export_spec.py` pass.