### PR TITLE
docs: add quick start guide and refresh home page

### DIFF
--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -1,0 +1,293 @@
+# Quick Start
+
+This guide walks you through installing Bank Statement Parser and running it on a folder of PDF bank statements for the first time. No technical experience is required.
+
+The whole process takes about five minutes.
+
+---
+
+## Before you begin
+
+You will need:
+
+- PDF statements downloaded from your bank's online portal
+- A folder to keep them in (e.g. `Documents/statements`)
+- An internet connection for the one-time installation
+
+!!! note "Supported statements"
+    Bank Statement Parser currently supports statements from **HSBC UK** (current accounts, savings accounts, and Rewards Credit Card) and **TSB UK** (Spend & Save current account). See the [home page](../index.md#supported-banks-and-accounts) for the full list.
+
+---
+
+## Step-by-step installation and first run
+
+=== "Windows"
+
+    ### Step 1 — Install uv
+
+    `uv` is a fast, lightweight tool that manages Python and Python packages for you. You do not need to install Python separately.
+
+    1. Open **PowerShell** — press `Win + S`, type `PowerShell`, and press Enter
+    2. Copy and paste the following command, then press Enter:
+
+        ```powershell
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+        ```
+
+    3. When it finishes, **close PowerShell and open a new window** — this ensures the new commands are available
+
+    !!! tip "Checking it worked"
+        In the new PowerShell window, type `uv --version` and press Enter. You should see a version number printed, such as `uv 0.5.0`.
+
+    ---
+
+    ### Step 2 — Install Bank Statement Parser
+
+    In your PowerShell window, run:
+
+    ```powershell
+    uv tool install uk-bank-statement-parser
+    ```
+
+    This downloads and installs the tool. It only needs to be done once.
+
+    !!! tip "Checking it worked"
+        Run `bsp --help` — you should see a list of available commands.
+
+    ---
+
+    ### Step 3 — Put your PDF statements in a folder
+
+    Create a folder somewhere easy to find, for example:
+
+    ```
+    C:\Users\YourName\Documents\statements
+    ```
+
+    Copy all of your PDF bank statements into that folder. They can be from different accounts and different months — Bank Statement Parser will sort them out.
+
+    ---
+
+    ### Step 4 — Run Bank Statement Parser
+
+    In PowerShell, run the following command, replacing the path with the location of your statements folder:
+
+    ```powershell
+    bsp process --pdfs "C:\Users\YourName\Documents\statements"
+    ```
+
+    You will see progress messages as each statement is processed. When it finishes, a new folder called `bsp_project` will have been created inside your statements folder.
+
+    ---
+
+    ### Step 5 — Find your output files
+
+    Open `C:\Users\YourName\Documents\statements\bsp_project\` in File Explorer.
+
+    Your exported files are in the **`export`** sub-folder:
+
+    ```
+    bsp_project\
+    └── export\
+        ├── transactions.csv        ← all transactions, one row per line
+        ├── transactions.xlsx       ← same data as an Excel workbook
+        └── balances.csv            ← opening and closing balances per statement
+    ```
+
+    Open `transactions.xlsx` in Excel to see all of your transactions in one place.
+
+    !!! tip "Running again later"
+        When you receive new statements, just copy them into the same folder and run the same `bsp process` command again. Existing records will not be duplicated.
+
+=== "macOS"
+
+    ### Step 1 — Install uv
+
+    `uv` is a fast, lightweight tool that manages Python and Python packages for you. You do not need to install Python separately.
+
+    1. Open **Terminal** — press `Cmd + Space`, type `Terminal`, and press Enter
+    2. Copy and paste the following command, then press Enter:
+
+        ```bash
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        ```
+
+    3. When it finishes, run the following to make the new commands available in your current window:
+
+        ```bash
+        source $HOME/.local/bin/env
+        ```
+
+    !!! tip "Checking it worked"
+        Type `uv --version` and press Enter. You should see a version number printed, such as `uv 0.5.0`.
+
+    ---
+
+    ### Step 2 — Install Bank Statement Parser
+
+    In Terminal, run:
+
+    ```bash
+    uv tool install uk-bank-statement-parser
+    ```
+
+    This downloads and installs the tool. It only needs to be done once.
+
+    !!! tip "Checking it worked"
+        Run `bsp --help` — you should see a list of available commands.
+
+    ---
+
+    ### Step 3 — Put your PDF statements in a folder
+
+    Create a folder somewhere easy to find, for example:
+
+    ```
+    /Users/yourname/Documents/statements
+    ```
+
+    In Finder you can do this by going to **Documents** and pressing `Shift + Cmd + N` to create a new folder called `statements`.
+
+    Copy all of your PDF bank statements into that folder. They can be from different accounts and different months — Bank Statement Parser will sort them out.
+
+    ---
+
+    ### Step 4 — Run Bank Statement Parser
+
+    In Terminal, run the following command, replacing the path with the location of your statements folder:
+
+    ```bash
+    bsp process --pdfs ~/Documents/statements
+    ```
+
+    You will see progress messages as each statement is processed. When it finishes, a new folder called `bsp_project` will have been created inside your statements folder.
+
+    ---
+
+    ### Step 5 — Find your output files
+
+    Open Finder and navigate to:
+
+    ```
+    ~/Documents/statements/bsp_project/export/
+    ```
+
+    Your exported files are:
+
+    ```
+    bsp_project/
+    └── export/
+        ├── transactions.csv        ← all transactions, one row per line
+        ├── transactions.xlsx       ← same data as an Excel workbook
+        └── balances.csv            ← opening and closing balances per statement
+    ```
+
+    Open `transactions.xlsx` in Numbers or Excel to see all of your transactions in one place.
+
+    !!! tip "Running again later"
+        When you receive new statements, just copy them into the same folder and run the same `bsp process` command again. Existing records will not be duplicated.
+
+=== "Linux"
+
+    ### Step 1 — Install uv
+
+    `uv` is a fast, lightweight tool that manages Python and Python packages for you. You do not need to install Python separately.
+
+    1. Open a **terminal**
+    2. Copy and paste the following command, then press Enter:
+
+        ```bash
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        ```
+
+    3. When it finishes, run the following to make the new commands available in your current session:
+
+        ```bash
+        source $HOME/.local/bin/env
+        ```
+
+    !!! tip "Checking it worked"
+        Type `uv --version` and press Enter. You should see a version number printed, such as `uv 0.5.0`.
+
+    ---
+
+    ### Step 2 — Install Bank Statement Parser
+
+    In your terminal, run:
+
+    ```bash
+    uv tool install uk-bank-statement-parser
+    ```
+
+    This downloads and installs the tool. It only needs to be done once.
+
+    !!! tip "Checking it worked"
+        Run `bsp --help` — you should see a list of available commands.
+
+    ---
+
+    ### Step 3 — Put your PDF statements in a folder
+
+    Create a folder somewhere easy to find, for example:
+
+    ```bash
+    mkdir -p ~/Documents/statements
+    ```
+
+    Copy all of your PDF bank statements into that folder. They can be from different accounts and different months — Bank Statement Parser will sort them out.
+
+    ---
+
+    ### Step 4 — Run Bank Statement Parser
+
+    Run the following command, replacing the path with the location of your statements folder:
+
+    ```bash
+    bsp process --pdfs ~/Documents/statements
+    ```
+
+    You will see progress messages as each statement is processed. When it finishes, a new folder called `bsp_project` will have been created inside your statements folder.
+
+    ---
+
+    ### Step 5 — Find your output files
+
+    Navigate to the output folder:
+
+    ```bash
+    cd ~/Documents/statements/bsp_project/export/
+    ls
+    ```
+
+    Your exported files are:
+
+    ```
+    bsp_project/
+    └── export/
+        ├── transactions.csv        ← all transactions, one row per line
+        ├── transactions.xlsx       ← same data as an Excel workbook
+        └── balances.csv            ← opening and closing balances per statement
+    ```
+
+    Open `transactions.xlsx` in LibreOffice Calc or any spreadsheet application to see all of your transactions in one place.
+
+    !!! tip "Running again later"
+        When you receive new statements, just copy them into the same folder and run the same `bsp process` command again. Existing records will not be duplicated.
+
+---
+
+## Something went wrong?
+
+| Problem | What to try |
+|---|---|
+| `bsp: command not found` | Close your terminal/PowerShell window and open a fresh one, then try again |
+| A statement was not processed | Check it is from a [supported bank](../index.md#supported-banks-and-accounts) and that the PDF is not password-protected |
+| The export folder is empty | Check the terminal output for any error messages and raise an issue on [GitHub](https://github.com/boscorat/bank_statement_parser/issues) |
+
+---
+
+## What's next?
+
+- **[Export Options](exports.md)** — learn about CSV, Excel, and QuickBooks export formats
+- **[Anonymisation](anonymisation.md)** — redact personal details from PDFs before sharing them
+- **[Project Structure](project-structure.md)** — understand how your output files are organised

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,37 +1,57 @@
 # Bank Statement Parser
 
-Welcome to the documentation for **bank_statement_parser** — a Python library for parsing
-bank statement PDFs, extracting structured transaction data, and persisting results to
-Parquet files and a SQLite star-schema data mart.
+Stop copying transactions from PDF statements into spreadsheets by hand. **Bank Statement Parser** reads your bank statement PDFs, pulls out every transaction automatically, and gives you clean, ready-to-use files — CSV, Excel, or direct import formats for accounting software.
 
-## Guides
+Everything runs on your own computer. No data is sent anywhere.
 
-- **[Adding a New Bank](guides/new-bank-config.md)** — step-by-step guide to creating
-  configuration files for parsing statements from a new bank, including the TOML file
-  structure, field extraction rules, and standard field mappings.
-- **[Anonymisation](guides/anonymisation.md)** — redacting personally identifiable
-  information from statement PDFs, config setup, and output review.
-- **[Project Structure](guides/project-structure.md)** — directory layout, SQLite
-  schema, and Parquet file organisation.
-- **[Export Options](guides/exports.md)** — simple vs. full export presets, CSV and
-  Excel output.
+---
 
-## Reference
+## What it does for you
 
-- **[CLI Reference](reference/cli.md)** — all `bsp process` and `bsp anonymise`
-  options with examples.
-- **[Python API Reference](reference/python-api.md)** — `StatementBatch`, report
-  backends, export helpers, and database utilities.
+- **Reads your PDF statements** — drop a folder of PDFs in, get structured data out
+- **No manual re-entry** — dates, amounts, descriptions, and running balances are all extracted automatically
+- **Export to the format you need** — CSV, Excel, or QuickBooks-compatible import files
+- **Handles multiple accounts at once** — current accounts, savings accounts, and credit cards in one pass
+- **Avoids duplicates** — re-running on the same statements won't create duplicate records
+- **Works fully offline** — your statements never leave your machine
+- **Free and open source** — no subscription, no sign-up
 
-## Quick Links
+---
+
+## Supported banks and accounts
+
+| Bank | Supported accounts |
+|---|---|
+| **HSBC UK** | Bank Account (Current), HSBC Advance, Flexible Saver, Online Bonus Saver, Rewards Credit Card |
+| **TSB UK** | Spend & Save (Current Account) |
+| **NatWest UK** | *(coming soon)* |
+
+> Support for more banks can be added by creating configuration files. See the [Adding a New Bank](guides/new-bank-config.md) guide.
+
+---
+
+## Getting started
+
+New to Bank Statement Parser? The [Quick Start guide](guides/quick-start.md) walks you through installation and your first run step by step — no technical experience needed.
+
+---
+
+## Going further
+
+| | |
+|---|---|
+| [Quick Start](guides/quick-start.md) | Install and run for the first time |
+| [Export Options](guides/exports.md) | CSV, Excel, and accounting software formats |
+| [Anonymisation](guides/anonymisation.md) | Redact personal details from PDFs before sharing |
+| [Project Structure](guides/project-structure.md) | How output files and folders are organised |
+| [Adding a New Bank](guides/new-bank-config.md) | Configure support for a bank not listed above |
+| [CLI Reference](reference/cli.md) | All command-line options |
+| [Python API Reference](reference/python-api.md) | Automate from your own scripts |
+
+---
+
+## Links
 
 - [GitHub Repository](https://github.com/boscorat/bank_statement_parser)
 - [PyPI Package](https://pypi.org/project/uk-bank-statement-parser/)
 - [Issue Tracker](https://github.com/boscorat/bank_statement_parser/issues)
-
-## About This Documentation
-
-This site is built with [Zensical](https://zensical.org/), a modern static site
-generator compatible with the Material for MkDocs theme. Reference pages and guide
-sections are **auto-generated** from docstrings and comments in the source code using
-`scripts/generate_docs.py`, ensuring the documentation stays in sync with the codebase.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Quick Start: guides/quick-start.md
   - Guides:
       - Adding a New Bank: guides/new-bank-config.md
       - Anonymisation: guides/anonymisation.md


### PR DESCRIPTION
## Summary

- **New page — Quick Start** (`docs/guides/quick-start.md`): a non-technical, step-by-step guide split into Windows, macOS, and Linux tabs covering `uv` installation, package install, running against a PDF folder, and finding output files. Includes a troubleshooting table and links to further reading.
- **Home page refresh** (`docs/index.md`): rewritten with a benefits-first lead, a supported banks & accounts table (HSBC UK, TSB UK, NatWest UK coming soon), and a cleaner navigation table replacing the old link lists. Removes the broken "Zensical" reference.
- **Nav update** (`mkdocs.yml`): Quick Start added as a top-level nav entry between Home and Guides so it is immediately visible without expanding any section.

## Motivation

The existing home page led with internal technical terminology (Parquet, star-schema data mart) and the Guides section was aimed at developers. This PR makes the site useful to non-technical end users while leaving all existing auto-generated reference content untouched.