### PR TITLE
fix: protect month names from substring scrambling; scaffold user config on new project

### DIFF
--- a/src/bank_statement_parser/modules/anonymise.py
+++ b/src/bank_statement_parser/modules/anonymise.py
@@ -284,6 +284,16 @@ def _build_full_page_scramble_pairs(
     pairs: list[tuple[str, str]] = []
     seen: set[str] = set()
 
+    # Build a set of normalised protected phrases for fast substring-guard lookups.
+    # A word whose normalised form appears as a substring of any protected phrase
+    # must not be added to the scramble pairs, because _apply_string_scramble uses
+    # str.replace (substring matching), and a pair like ("J", scrambled_J) would
+    # corrupt "Jun" inside a Tj fragment such as "09 Jun 25".
+    _protected_phrases: frozenset[str] = config.words_to_not_scramble
+
+    def _is_substring_of_protected(normalised_word: str) -> bool:
+        return any(normalised_word in phrase for phrase in _protected_phrases)
+
     for w in words:
         text: str = w["text"].strip()
         if not text or text in seen:
@@ -293,6 +303,14 @@ def _build_full_page_scramble_pairs(
 
         # Protected word/phrase — skip entirely.
         if normalised in config.words_to_not_scramble:
+            seen.add(text)
+            continue
+
+        # Skip words whose normalised form is a substring of any protected phrase.
+        # Without this guard a short word such as "J" (a name initial) would produce
+        # a scramble pair that corrupts the "J" inside "Jun" when str.replace is
+        # applied to a Tj fragment like "09 Jun 25".
+        if _is_substring_of_protected(normalised):
             seen.add(text)
             continue
 
@@ -399,18 +417,26 @@ def _build_full_page_scramble_bytes_pairs(
         return []
 
     fragments: list[tuple[bytes, str]] = []
-    current_font: str = next(iter(forward_maps))
+    current_font: str = ""  # tracks the active font; may or may not be in forward_maps
 
     for operands, operator in instructions:
         op = str(operator)
         if op == "Tf" and operands:
             try:
-                candidate = str(operands[0])
-                if candidate in forward_maps:
-                    current_font = candidate
+                # Always update current_font, even for non-ToUnicode fonts.
+                # This prevents stale ToUnicode font names being used to decode
+                # Tj fragments that actually belong to a WinAnsiEncoding font
+                # (which is how HSBC statements are structured).
+                current_font = str(operands[0])
             except Exception:
                 pass
         elif op == "Tj" and operands:
+            # Only collect fragments for fonts that have a ToUnicode CMap.
+            # Skipping non-ToUnicode fonts (e.g. HSBC WinAnsiEncoding) ensures
+            # the fragment list is empty for those pages, causing the function
+            # to return [] and correctly fall back to the Latin-1 string path.
+            if current_font not in forward_maps:
+                continue
             try:
                 raw = bytes(operands[0])
                 if raw:
@@ -418,6 +444,8 @@ def _build_full_page_scramble_bytes_pairs(
             except Exception:
                 pass
         elif op == "TJ" and operands:
+            if current_font not in forward_maps:
+                continue
             try:
                 arr = operands[0]
                 for item in list(arr):  # type: ignore[arg-type]

--- a/src/bank_statement_parser/modules/paths.py
+++ b/src/bank_statement_parser/modules/paths.py
@@ -610,7 +610,16 @@ def _scaffold_new_project(paths: ProjectPaths) -> None:
             if not dst.exists():
                 shutil.copy2(src, dst)
 
-    # 5. Create the SQLite database with the full schema.
+    # 5. Copy user config files from the default config/user/ (e.g. anonymise_example.toml).
+    for src in BASE_CONFIG_USER.rglob("*"):
+        if src.is_file():
+            relative = src.relative_to(BASE_CONFIG_USER)
+            dst = paths.config_user.joinpath(relative)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if not dst.exists():
+                shutil.copy2(src, dst)
+
+    # 6. Create the SQLite database with the full schema.
     #    Import here to avoid a circular dependency at module level
     #    (database.py → paths.py; paths.py must not import database.py at top).
     from bank_statement_parser.data.create_project_db import main as create_db  # noqa: PLC0415


### PR DESCRIPTION
## Summary

- **Month name regression fix** (`anonymise.py`): When anonymising HSBC statements, standalone name initials (e.g. `J` from `Mr J T M Farrar`) were extracted by pdfplumber as words and added to the scramble pairs. Because `_apply_string_scramble` uses `str.replace` (substring matching), the pair `("J", "F")` was applied to full Tj strings like `"09 Jun 25"`, corrupting the month's initial letter on every run (with a random replacement letter each time). Fix: skip any word whose normalised form is a substring of any protected phrase — `"j"` is a substring of `"jun"`, `"jul"`, `"january"` etc., so name initials are excluded from pairs. Also includes the earlier font-routing fix: `current_font` is now always updated on `Tf` changes, and Tj/TJ fragments are only collected for fonts that have a ToUnicode CMap.

- **Project scaffold fix** (`paths.py`): `_scaffold_new_project` was missing a copy step for `BASE_CONFIG_USER` (the `config/user/` directory). New projects now receive `anonymise_example.toml` (and any future user config files) alongside the existing import/export/report configs.