### PR TITLE
security: harden GitHub Actions workflows and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7  # wait 7 days before raising a PR for a new release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,23 @@ on:
   pull_request:
     branches: [master]
 
+permissions: {}  # no workflow-level permissions; each job declares its own
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --group dev

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,12 +31,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -47,9 +51,9 @@ jobs:
       - name: Build site
         run: uv run zensical build --clean
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
         with:
           path: site
 
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ on:
     tags:
       - "v*"
 
+permissions: {}  # no workflow-level permissions; each job declares its own
+
 jobs:
   # ── Build wheel + sdist and publish to PyPI ─────────────────────────
   pypi-publish:
@@ -32,10 +34,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          enable-cache: false
 
       - name: Install Python
         run: uv python install 3.14.2
@@ -67,7 +73,7 @@ jobs:
         run: uv publish
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: python-dists
           path: dist/
@@ -77,12 +83,18 @@ jobs:
     name: Build .deb and .rpm
     runs-on: ubuntu-24.04
     needs: pypi-publish
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          enable-cache: false
 
       - name: Install Python 3.14.2
         run: uv python install 3.14.2
@@ -152,12 +164,14 @@ jobs:
           chmod 755 /tmp/bsp-pkg/usr/bin/bsp
 
       - name: Build .deb
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           fpm \
             -s dir \
             -t deb \
             -n uk-bank-statement-parser \
-            -v "${{ steps.version.outputs.version }}" \
+            -v "${PKG_VERSION}" \
             --description "Parse bank statement PDFs, extract transactions, persist to Parquet and SQLite." \
             --license "MIT" \
             --maintainer "Jason Farrar <farrar.jason1@gmail.com>" \
@@ -166,17 +180,19 @@ jobs:
             --category "utils" \
             --architecture all \
             --deb-no-default-config-files \
-            -p "uk-bank-statement-parser_${{ steps.version.outputs.version }}_all.deb" \
+            -p "uk-bank-statement-parser_${PKG_VERSION}_all.deb" \
             /tmp/bsp-venv/=/opt/uk-bank-statement-parser/ \
             /tmp/bsp-pkg/usr/bin/bsp=/usr/bin/bsp
 
       - name: Build .rpm
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           fpm \
             -s dir \
             -t rpm \
             -n uk-bank-statement-parser \
-            -v "${{ steps.version.outputs.version }}" \
+            -v "${PKG_VERSION}" \
             --description "Parse bank statement PDFs, extract transactions, persist to Parquet and SQLite." \
             --license "MIT" \
             --maintainer "Jason Farrar <farrar.jason1@gmail.com>" \
@@ -185,12 +201,12 @@ jobs:
             --category "Utilities" \
             --architecture all \
             --rpm-os linux \
-            -p "uk-bank-statement-parser-${{ steps.version.outputs.version }}-1.noarch.rpm" \
+            -p "uk-bank-statement-parser-${PKG_VERSION}-1.noarch.rpm" \
             /tmp/bsp-venv/=/opt/uk-bank-statement-parser/ \
             /tmp/bsp-pkg/usr/bin/bsp=/usr/bin/bsp
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: system-packages
           path: |
@@ -206,19 +222,19 @@ jobs:
       contents: write
     steps:
       - name: Download Python dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-dists
           path: dist/
 
       - name: Download system packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: system-packages
           path: packages/
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Summary

Addresses all findings raised by [zizmor](https://docs.zizmor.sh/) v1.24.1 across the three workflow files and `dependabot.yml`. Result: **0 high, 0 medium, 0 low** findings (down from 18 high + 8 medium + 5 informational).

## Changes

### `unpinned-uses` (High) — all action tags pinned to commit SHAs
Every `uses:` reference now points to an immutable commit SHA, with the human-readable tag kept as a comment. Covers 8 distinct actions across `ci.yml`, `docs.yml`, and `release.yml`.

### `artipacked` (Low) — `persist-credentials: false` on all checkouts
Added to all 3 `actions/checkout` steps across `ci.yml` and `release.yml`.

### `template-injection` (Informational) — context values moved to `env:` vars
`steps.version.outputs.version` moved out of `run:` blocks into a `PKG_VERSION` env var for the `.deb` and `.rpm` `fpm` build steps in `release.yml`.

### `cache-poisoning` (Low) — uv caching disabled
Added `enable-cache: false` to all 2 `astral-sh/setup-uv` steps in `release.yml` and 1 in `ci.yml`.

### `excessive-permissions` (Medium) — permissions scoped to minimum
- `ci.yml`: `permissions: {}` at workflow level; `contents: read` on `lint-and-test` job
- `release.yml`: `permissions: {}` at workflow level; `contents: read` added to `system-packages` job (previously had none)
- `docs.yml`: existing per-job permissions block retained (already correctly scoped)

### `dependabot-cooldown` (Medium) — 7-day cooldown added
Added `cooldown: default-days: 7` to the uv ecosystem entry in `dependabot.yml`. Dependabot will now wait a week before raising PRs for brand-new package releases, reducing the window for supply-chain attacks via newly published packages.