### PR TITLE
docs: add GitHub issue templates for new bank requests and parsing issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question / start a discussion
+    url: https://github.com/boscorat/bank_statement_parser/discussions
+    about: Use GitHub Discussions for questions, ideas, and general conversation.

--- a/.github/ISSUE_TEMPLATE/new-bank-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-bank-request.yml
@@ -1,0 +1,78 @@
+name: "New bank request"
+description: "Request support for a bank or account type that isn't currently supported."
+title: "[New bank] "
+labels: ["new-bank"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a new bank. The more detail you can provide,
+        the easier it is to build and test the parser configuration.
+
+  - type: input
+    id: bank_name
+    attributes:
+      label: Bank name
+      description: The full name of the bank (e.g. "Lloyds Bank UK", "Barclays UK").
+      placeholder: e.g. Lloyds Bank UK
+    validations:
+      required: true
+
+  - type: input
+    id: account_type
+    attributes:
+      label: Account type(s)
+      description: >
+        The account type(s) whose statements you want parsed
+        (e.g. "Current account", "Cash ISA", "Credit card").
+      placeholder: e.g. Current account, Credit card
+    validations:
+      required: true
+
+  - type: textarea
+    id: statement_notes
+    attributes:
+      label: Statement format notes
+      description: >
+        Any details that might help — number of pages, whether transactions span
+        multiple lines, landscape layout, header/footer quirks, etc.
+      placeholder: e.g. "Statements are always two pages. Transactions can wrap to a second line. Running balance is in the rightmost column."
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Attaching an anonymised statement
+
+        > **You must anonymise your statement before attaching it.**
+        >
+        > An anonymised statement has all text scrambled so that no personal or financial
+        > information is readable, while preserving enough structure for the parser to work with.
+        >
+        > - Using **openstan**: use the built-in Anonymise PDF tool —
+        >   [openstan anonymisation guide](https://openstan.org/screens/anonymise/)
+        > - Using the **bsp CLI or Python API**: use `bsp anonymise` —
+        >   [bsp anonymisation guide](https://boscorat.github.io/bank_statement_parser/guides/anonymisation/)
+        >
+        > ⚠ **Statements that have not been anonymised will be removed without review.**
+
+  - type: textarea
+    id: statement_attachment
+    attributes:
+      label: Anonymised statement
+      description: >
+        Drag and drop your anonymised PDF here, or describe why you are unable to attach one.
+        GitHub accepts PDF attachments directly in this field.
+      placeholder: Drag and drop the anonymised PDF here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Anything else that might be useful — links to the bank's online statement portal, known quirks, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/parsing-issue.yml
+++ b/.github/ISSUE_TEMPLATE/parsing-issue.yml
@@ -1,0 +1,90 @@
+name: "Parsing issue"
+description: "Report a parsing error or unexpected result for a bank that is already supported."
+title: "[Parsing issue] <Bank name> — "
+labels: ["bug", "parsing"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Precise details and an anonymised statement make it
+        much faster to diagnose and fix parsing issues.
+
+  - type: input
+    id: bank_account
+    attributes:
+      label: Bank and account type
+      description: The bank name and account type that is failing to parse correctly.
+      placeholder: e.g. HSBC UK — Rewards Credit Card
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen? (e.g. "All 34 transactions should have been imported.")
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: >
+        What actually happened? If openstan showed a parsing error, paste the debug output
+        from the Import Results screen here. If using the CLI, paste the terminal output.
+      placeholder: Paste debug output or error message here.
+    validations:
+      required: true
+
+  - type: input
+    id: bsp_version
+    attributes:
+      label: bank_statement_parser version
+      description: >
+        Run `bsp --version` or check your `pyproject.toml` / `requirements.txt`.
+        In openstan, the version is shown on the About screen.
+      placeholder: e.g. 0.2.1b2
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Attaching an anonymised statement
+
+        > **You must anonymise your statement before attaching it.**
+        >
+        > An anonymised statement has all text scrambled so that no personal or financial
+        > information is readable, while preserving enough structure for the parser to work with.
+        >
+        > - Using **openstan**: use the built-in Anonymise PDF tool —
+        >   [openstan anonymisation guide](https://openstan.org/screens/anonymise/)
+        > - Using the **bsp CLI or Python API**: use `bsp anonymise` —
+        >   [bsp anonymisation guide](https://boscorat.github.io/bank_statement_parser/guides/anonymisation/)
+        >
+        > ⚠ **Statements that have not been anonymised will be removed without review.**
+
+  - type: textarea
+    id: statement_attachment
+    attributes:
+      label: Anonymised statement
+      description: >
+        Drag and drop your anonymised PDF here, or describe why you are unable to attach one.
+        GitHub accepts PDF attachments directly in this field.
+        Attaching the failing statement is strongly recommended — issues reported without one
+        may take significantly longer to investigate.
+      placeholder: Drag and drop the anonymised PDF here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: >
+        Anything else that might help — number of pages in the statement, whether it's a
+        downloaded PDF or a scanned copy, OS and Python version, etc.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds structured GitHub issue templates to make it easy for users to report parsing problems or request new bank support
- Both templates include a prominent anonymisation callout linking to both the openstan and bsp anonymisation guides, with a clear warning against attaching non-anonymised statements
- Blank issues remain allowed; a link to GitHub Discussions is added for general questions

## Files added

| File | Purpose |
|---|---|
| `.github/ISSUE_TEMPLATE/config.yml` | Template chooser config; adds Discussions link |
| `.github/ISSUE_TEMPLATE/new-bank-request.yml` | Form for requesting support for a new bank or account type |
| `.github/ISSUE_TEMPLATE/parsing-issue.yml` | Form for reporting a parsing error on an already-supported bank |

## Anonymisation guidance

Both templates include the following callout directing users to anonymise before attaching:

> **You must anonymise your statement before attaching it.**
> - Using **openstan**: [openstan anonymisation guide](https://openstan.org/screens/anonymise/)
> - Using the **bsp CLI or Python API**: [bsp anonymisation guide](https://boscorat.github.io/bank_statement_parser/guides/anonymisation/)
>
> ⚠ Statements that have not been anonymised will be removed without review.