### PR TITLE
fix: export date/datetime as native Excel cells; dynamic float precision

### DIFF
--- a/src/bank_statement_parser/modules/export_spec.py
+++ b/src/bank_statement_parser/modules/export_spec.py
@@ -43,6 +43,10 @@ _KNOWN_COMPUTED: frozenset[str] = frozenset({_COMPUTED_SIGNED_AMOUNT})
 # Columns in FlatTransaction that contain dates (need format conversion)
 _DATE_COLUMNS: frozenset[str] = frozenset({"transaction_date", "statement_date"})
 
+# Excel format strings for date/datetime columns.
+_EXCEL_DATE_FMT: str = "yyyy-mm-dd"
+_EXCEL_DATETIME_FMT: str = "yyyy-mm-dd hh:mm:ss"
+
 # Column used to partition rows when split_by_statement=True
 _SPLIT_ANCHOR = "id_statement"
 
@@ -352,24 +356,32 @@ def _apply_column_mapping(df: pl.LazyFrame, spec: ExportSpec) -> pl.LazyFrame:
 # ---------------------------------------------------------------------------
 
 
-def _apply_date_format(df: pl.LazyFrame, spec: ExportSpec) -> pl.LazyFrame:
-    """Cast and format date columns as strings using ``spec.date_format``.
+def _apply_date_format(df: pl.LazyFrame, spec: ExportSpec, *, keep_as_date: bool = False) -> pl.LazyFrame:
+    """Cast and format date columns using ``spec.date_format``.
 
     Any output column whose *source* in the spec maps to a known date column
-    (``transaction_date``, ``statement_date``) is cast to :class:`pl.Date`
-    and then formatted as a string.
+    (``transaction_date``, ``statement_date``) is cast to :class:`pl.Date`.
+    When *keep_as_date* is ``False`` (the default) the column is then formatted
+    as a string via :meth:`~polars.Expr.dt.strftime` — suitable for CSV output.
+    When *keep_as_date* is ``True`` the column is left as :class:`pl.Date` so
+    that Excel can render it as a native date cell via ``dtype_formats``.
 
     Args:
         df: :class:`pl.LazyFrame` after column mapping has been applied.
         spec: The loaded :class:`ExportSpec`.
+        keep_as_date: When ``True``, skip the string-formatting step and leave
+            columns as :class:`pl.Date`.  Defaults to ``False``.
 
     Returns:
-        The :class:`pl.LazyFrame` with date columns replaced by formatted strings.
+        The :class:`pl.LazyFrame` with date columns cast (and optionally
+        string-formatted).
     """
     # Identify output columns whose source was a date field
     date_output_cols: list[str] = [export_name for export_name, source in spec.columns.items() if source in _DATE_COLUMNS]
     if not date_output_cols:
         return df
+    if keep_as_date:
+        return df.with_columns([pl.col(col).cast(pl.Date).alias(col) for col in date_output_cols])
     return df.with_columns([pl.col(col).cast(pl.Date).dt.strftime(spec.date_format).alias(col) for col in date_output_cols])
 
 
@@ -502,6 +514,7 @@ def _write_frames(
                     table_name=re.sub(r"[^A-Za-z0-9_]", "_", stem),
                     table_style="Table Style Medium 4",
                     float_precision=spec.float_precision,
+                    dtype_formats={pl.Date: _EXCEL_DATE_FMT, pl.Datetime: _EXCEL_DATETIME_FMT},
                 )
             written.append(out_path)
     else:
@@ -606,7 +619,7 @@ def export_spec(
     # Query and transform
     lf = _build_frame(paths.project_db, loaded, account_key, date_from, date_to, statement_key)
     lf = _apply_column_mapping(lf, loaded)
-    lf = _apply_date_format(lf, loaded)
+    lf = _apply_date_format(lf, loaded, keep_as_date=(loaded.format == "xlsx"))
     lf = _apply_blank_zeros(lf, loaded)
     lf = _sanitise_strings(lf, loaded)
 
@@ -654,7 +667,7 @@ def export_spec(
                     stem = f"{account_key}_{date_str}"
                 partition = df_raw.filter(pl.col(_SPLIT_ANCHOR) == sid).lazy()
                 partition = _apply_column_mapping(partition, loaded)
-                partition = _apply_date_format(partition, loaded)
+                partition = _apply_date_format(partition, loaded, keep_as_date=(loaded.format == "xlsx"))
                 partition = _apply_blank_zeros(partition, loaded)
                 partition = _sanitise_strings(partition, loaded)
                 frames.append((stem, partition.collect()))

--- a/src/bank_statement_parser/modules/reports_db.py
+++ b/src/bank_statement_parser/modules/reports_db.py
@@ -122,9 +122,53 @@ def _read_data_filtered(db_path: Path, table_name: str, batch_table: str, batch_
         return pl.read_database(query, connection=conn, execute_options={"parameters": [batch_id]}, infer_schema_length=None).lazy()
 
 
-# Names of the numeric (float) tables in the full export — used by export_excel
-# to pass float_precision=2.
-_FLOAT_TABLES: frozenset[str] = frozenset({"transaction_measures", "daily_account_balances"})
+# Excel format strings for date/datetime columns cast from ISO strings.
+_EXCEL_DATE_FMT: str = "yyyy-mm-dd"
+_EXCEL_DATETIME_FMT: str = "yyyy-mm-dd hh:mm:ss"
+
+# Regex patterns used to detect ISO date/datetime strings in Utf8 columns.
+_ISO_DATE_RE: str = r"^\d{4}-\d{2}-\d{2}$"
+_ISO_DATETIME_RE: str = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+
+
+def _cast_date_columns(df: pl.DataFrame) -> pl.DataFrame:
+    """Cast ISO-format string columns to native date/datetime types for Excel export.
+
+    Inspects every ``Utf8`` column in *df*.  Columns whose non-null values all
+    match ``YYYY-MM-DD`` are cast to :class:`pl.Date`; columns whose non-null
+    values all match ``YYYY-MM-DDTHH:MM:SS…`` are cast to :class:`pl.Datetime`.
+    All other columns are left unchanged.
+
+    This allows :func:`export_excel` to pass ``dtype_formats`` hints to
+    ``write_excel`` so that Excel receives native date/datetime cells rather than
+    plain text strings.
+
+    Args:
+        df: The DataFrame to process.
+
+    Returns:
+        A new :class:`pl.DataFrame` with date/datetime columns cast appropriately.
+    """
+    date_cols: list[str] = []
+    datetime_cols: list[str] = []
+    for col in df.columns:
+        if df[col].dtype != pl.Utf8:
+            continue
+        non_null = df[col].drop_nulls()
+        if non_null.is_empty():
+            continue
+        if non_null.str.contains(_ISO_DATETIME_RE).all():
+            datetime_cols.append(col)
+        elif non_null.str.contains(_ISO_DATE_RE).all():
+            date_cols.append(col)
+    exprs: list[pl.Expr] = []
+    if date_cols:
+        exprs.extend(pl.col(c).cast(pl.Date) for c in date_cols)
+    if datetime_cols:
+        exprs.extend(pl.col(c).str.to_datetime(format="%Y-%m-%dT%H:%M:%S", strict=False) for c in datetime_cols)
+    if not exprs:
+        return df
+    return df.with_columns(exprs)
 
 
 def _ts() -> str:
@@ -307,13 +351,16 @@ def export_excel(
         path = path.parent / f"{path.stem}_{_ts()}{path.suffix}"
     with Workbook(str(path)) as wb:
         for name, df in _collect_report_frames(type, project_path, batch_id):
-            extra: dict = {"float_precision": 2} if name in _FLOAT_TABLES else {}
+            df = _cast_date_columns(df)
+            has_floats = any(df[col].dtype in (pl.Float32, pl.Float64) for col in df.columns)
+            extra: dict = {"float_precision": 2} if has_floats else {}
             df.write_excel(
                 workbook=wb,
                 worksheet=name,
                 autofit=False,
                 table_name=name,
                 table_style="Table Style Medium 4",
+                dtype_formats={pl.Date: _EXCEL_DATE_FMT, pl.Datetime: _EXCEL_DATETIME_FMT},
                 **extra,
             )
 


### PR DESCRIPTION
## Summary

- **Date/datetime columns exported as native Excel cells** rather than plain text strings. A new `_cast_date_columns()` helper in `reports_db.py` inspects `Utf8` columns at export time: values matching `YYYY-MM-DD` are cast to `pl.Date`; values matching `YYYY-MM-DDTHH:MM:SS…` are cast to `pl.Datetime`. Excel format strings (`yyyy-mm-dd` / `yyyy-mm-dd hh:mm:ss`) are passed via `dtype_formats` to `write_excel`.
- **Float precision driven dynamically** in `reports_db.export_excel`: the hardcoded `_FLOAT_TABLES` frozenset is removed and replaced with a per-DataFrame dtype check (`pl.Float32`/`pl.Float64` present → `float_precision=2`). Any current or future table containing floats is handled automatically.
- **`export_spec.py` xlsx path** receives the same `dtype_formats` hint. `_apply_date_format` gains a `keep_as_date` kwarg — when writing xlsx the columns are left as `pl.Date` for Excel to format natively; the CSV path continues to use `spec.date_format` via `strftime` unchanged.

All 202 tests pass. No new hardcoded column or table names introduced.