### PR TITLE
Test: Private PDF repo SSH integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Set up SSH for private repo access
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_TEST_DATA }}
+
       - name: Ruff lint
         run: uv run ruff check .
 

--- a/src/bank_statement_parser/testing.py
+++ b/src/bank_statement_parser/testing.py
@@ -4,7 +4,8 @@ testing.py — programmatic test harness for dependent projects.
 Exposes :class:`TestHarness`, which allows an external project (e.g. *openstan*)
 to:
 
-1. Build a fully-populated bsp project from the bundled anonymised PDFs.
+1. Build a fully-populated bsp project from anonymised PDFs (bundled or from
+   the private ``boscorat/bank-statement-data`` repo via SSH).
 2. Run bsp's own pytest suite as a quality gate.
 3. Obtain the path to the resulting SQLite database for direct comparison queries.
 4. Tear the temporary project down when finished.
@@ -25,7 +26,8 @@ Typical usage::
         compare_databases(h.db_path, openstan_db_path)
 
 Functions:
-    _pdf_dir: Returns the path to the bundled test PDFs for a given category.
+    _pdf_dir: Returns the path to test PDFs (bundled or cloned from private repo).
+    _clone_test_data: Clones test PDFs from private repo if not bundled.
     _tests_dir: Returns the path to the bsp pytest suite (dev/editable installs only).
 """
 
@@ -49,28 +51,99 @@ _PDFS_DIR: Path = _TEST_DATA_DIR / "pdfs"
 # Repo root is three levels up: src/bank_statement_parser/testing.py → repo root
 _REPO_ROOT: Path = Path(__file__).parent.parent.parent
 
+# Cache directory for cloned test data (cross-platform)
+_CACHE_DIR: Path = Path.home() / ".cache" / "bank_statement_data"
+_PRIVATE_REPO_URL: str = "git@github.com:boscorat/bank-statement-data.git"
 
-def _pdf_dir(category: str) -> Path:
-    """Return the bundled test-PDF directory for *category* (``"good"`` or ``"bad"``).
 
-    The PDFs live inside the installed package at
-    ``bank_statement_parser/test_data/pdfs/<category>/`` so this function works
-    from both editable and wheel installs.
+def _clone_test_data() -> Path | None:
+    """Attempt to clone test data from private repo into cache directory.
+
+    Clones ``boscorat/bank-statement-data`` repo via SSH into ``~/.cache/bank_statement_data/``.
+    Uses SSH for authentication (requires SSH key access to the private repo).
+    Extracts the ``pdf`` directory from the repo root.
+
+    Returns:
+        Absolute :class:`~pathlib.Path` to the extracted ``pdf`` directory if successful.
+        ``None`` if the clone fails (missing SSH key, network error, etc.).
+
+    Note:
+        The clone is cached locally to avoid repeated downloads. Subsequent calls
+        will reuse the existing cache if it already exists.
+    """
+    pdf_cache = _CACHE_DIR / "pdf"
+
+    # If already cached, return immediately
+    if pdf_cache.is_dir():
+        return pdf_cache
+
+    # Attempt to clone
+    try:
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        # Clone into a temporary subdirectory to avoid conflicts
+        repo_dir = _CACHE_DIR / "repo"
+
+        result = subprocess.run(
+            ["git", "clone", _PRIVATE_REPO_URL, str(repo_dir)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            return None
+
+        # Extract pdf directory from cloned repo
+        repo_pdf = repo_dir / "pdf"
+        if not repo_pdf.is_dir():
+            return None
+
+        # Move pdf directory to cache location
+        repo_pdf.replace(pdf_cache)
+        # Clean up the now-empty repo directory
+        if repo_dir.exists():
+            shutil.rmtree(repo_dir, ignore_errors=True)
+
+        return pdf_cache if pdf_cache.is_dir() else None
+    except FileNotFoundError, subprocess.TimeoutExpired:
+        # FileNotFoundError: git not found
+        # TimeoutExpired: clone took too long
+        return None
+
+
+def _pdf_dir(category: str) -> Path | None:
+    """Return the test-PDF directory for *category* (``"good"`` or ``"bad"``).
+
+    First attempts to use bundled PDFs in the installed package at
+    ``bank_statement_parser/test_data/pdfs/<category>/``.  If not found,
+    attempts to clone from the private repo ``boscorat/bank-statement-data``
+    via SSH, caching the result locally.
 
     Args:
         category: Either ``"good"`` (real, anonymised PDFs that parse cleanly)
             or ``"bad"`` (PDFs that are expected to produce errors).
 
     Returns:
-        Absolute :class:`~pathlib.Path` to the requested PDF directory.
+        Absolute :class:`~pathlib.Path` to the requested PDF directory if found.
+        ``None`` if neither bundled PDFs nor remote clone are available.
 
-    Raises:
-        FileNotFoundError: If the directory does not exist inside the package.
+    Note:
+        Returns ``None`` rather than raising an exception to allow graceful
+        test skipping when PDFs are unavailable (e.g., users without SSH access
+        to the private repo).
     """
-    path = _PDFS_DIR / category
-    if not path.is_dir():
-        raise FileNotFoundError(f"Bundled PDF directory not found: {path}")
-    return path
+    # Try bundled path first
+    bundled_path = _PDFS_DIR / category
+    if bundled_path.is_dir():
+        return bundled_path
+
+    # Try to clone from private repo
+    pdf_cache = _clone_test_data()
+    if pdf_cache is not None:
+        cached_path = pdf_cache / category
+        if cached_path.is_dir():
+            return cached_path
+
+    return None
 
 
 def _tests_dir() -> Path:

--- a/src/bank_statement_parser/testing.py
+++ b/src/bank_statement_parser/testing.py
@@ -61,21 +61,21 @@ def _clone_test_data() -> Path | None:
 
     Clones ``boscorat/bank-statement-data`` repo via SSH into ``~/.cache/bank_statement_data/``.
     Uses SSH for authentication (requires SSH key access to the private repo).
-    Extracts the ``pdf`` directory from the repo root.
+    Extracts the ``pdfs`` directory from the repo root.
 
     Returns:
-        Absolute :class:`~pathlib.Path` to the extracted ``pdf`` directory if successful.
+        Absolute :class:`~pathlib.Path` to the extracted ``pdfs`` directory if successful.
         ``None`` if the clone fails (missing SSH key, network error, etc.).
 
     Note:
         The clone is cached locally to avoid repeated downloads. Subsequent calls
         will reuse the existing cache if it already exists.
     """
-    pdf_cache = _CACHE_DIR / "pdf"
+    pdfs_cache = _CACHE_DIR / "pdfs"
 
     # If already cached, return immediately
-    if pdf_cache.is_dir():
-        return pdf_cache
+    if pdfs_cache.is_dir():
+        return pdfs_cache
 
     # Attempt to clone
     try:
@@ -92,18 +92,18 @@ def _clone_test_data() -> Path | None:
         if result.returncode != 0:
             return None
 
-        # Extract pdf directory from cloned repo
-        repo_pdf = repo_dir / "pdf"
-        if not repo_pdf.is_dir():
+        # Extract pdfs directory from cloned repo
+        repo_pdfs = repo_dir / "pdfs"
+        if not repo_pdfs.is_dir():
             return None
 
-        # Move pdf directory to cache location
-        repo_pdf.replace(pdf_cache)
+        # Move pdfs directory to cache location
+        repo_pdfs.replace(pdfs_cache)
         # Clean up the now-empty repo directory
         if repo_dir.exists():
             shutil.rmtree(repo_dir, ignore_errors=True)
 
-        return pdf_cache if pdf_cache.is_dir() else None
+        return pdfs_cache if pdfs_cache.is_dir() else None
     except FileNotFoundError, subprocess.TimeoutExpired:
         # FileNotFoundError: git not found
         # TimeoutExpired: clone took too long

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,18 @@ conftest.py — session-scoped fixtures for integration tests.
 Two project lifecycles are provided:
 
 ``good_project``
-    Processes all PDFs in the bundled ``test_data/pdfs/good/`` directory into a
-    fresh project at ``tests/test_project/``.  The project is fully populated
+    Processes all PDFs in the ``test_data/pdfs/good/`` directory (bundled or
+    cloned from the private ``boscorat/bank-statement-data`` repo) into a fresh
+    project at ``tests/test_project/``.  The project is fully populated
     (parquet + SQLite) before any test runs, and torn down afterwards.
+    Skipped if PDF fixtures are unavailable (e.g., no SSH access to private repo).
 
 ``bad_project``
-    Processes all PDFs in the bundled ``test_data/pdfs/bad/`` directory into a
-    fresh project at ``tests/test_project_bad/``.  Used to verify that bad PDFs
+    Processes all PDFs in the ``test_data/pdfs/bad/`` directory (bundled or
+    cloned from the private ``boscorat/bank-statement-data`` repo) into a fresh
+    project at ``tests/test_project_bad/``.  Used to verify that bad PDFs
     are flagged as errors rather than processed successfully.
+    Skipped if PDF fixtures are unavailable (e.g., no SSH access to private repo).
 """
 
 import shutil
@@ -31,6 +35,9 @@ _BAD_PDFS_DIR = _pdf_dir("bad")
 _GOOD_PROJECT_DIR = _TESTS_DIR / "test_project"
 _BAD_PROJECT_DIR = _TESTS_DIR / "test_project_bad"
 
+# Track whether PDF fixtures are available for session-end summary
+_PDF_FIXTURES_AVAILABLE = _GOOD_PDFS_DIR is not None and _BAD_PDFS_DIR is not None
+
 
 @dataclass
 class ProjectContext:
@@ -46,7 +53,12 @@ def good_project() -> Generator[ProjectContext, None, None]:  # type: ignore[mis
     """
     Session fixture: scaffold a fresh project, process all good PDFs,
     populate parquet and SQLite, then yield.  Tears down on session end.
+
+    Skipped if PDF fixtures are unavailable (e.g., no SSH access to private repo).
     """
+    if _GOOD_PDFS_DIR is None:
+        pytest.skip("Good PDF fixtures unavailable (requires boscorat/bank-statement-data access)")
+
     project_path = _GOOD_PROJECT_DIR
     project_path.mkdir(parents=True, exist_ok=True)
 
@@ -75,7 +87,12 @@ def bad_project() -> Generator[ProjectContext, None, None]:  # type: ignore[misc
     """
     Session fixture: scaffold a fresh project, process all bad PDFs,
     then yield.  Tears down on session end.
+
+    Skipped if PDF fixtures are unavailable (e.g., no SSH access to private repo).
     """
+    if _BAD_PDFS_DIR is None:
+        pytest.skip("Bad PDF fixtures unavailable (requires boscorat/bank-statement-data access)")
+
     project_path = _BAD_PROJECT_DIR
     project_path.mkdir(parents=True, exist_ok=True)
 
@@ -95,3 +112,22 @@ def bad_project() -> Generator[ProjectContext, None, None]:  # type: ignore[misc
     finally:
         if project_path.exists():
             shutil.rmtree(project_path)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Display session summary, including skipped PDF-dependent tests if applicable."""
+    if not _PDF_FIXTURES_AVAILABLE:
+        print("\n" + "=" * 70)
+        print("PDF-DEPENDENT TESTS SKIPPED")
+        print("=" * 70)
+        print(
+            "\nThese tests require anonymised bank statement PDFs from the private repo:\n"
+            "  boscorat/bank-statement-data\n"
+            "\nTo run these tests locally:\n"
+            "  1. Ensure you have SSH access to boscorat/bank-statement-data\n"
+            "  2. Set up your SSH key (~/.ssh/id_rsa or similar)\n"
+            "  3. Run pytest again\n"
+            "\nIn CI, these tests will run automatically with SSH secret access.\n"
+        )
+        print("=" * 70 + "\n")


### PR DESCRIPTION
Tests the new SSH-based fallback mechanism for loading PDFs from private repo.

- All 202 tests pass locally
- Tests pass with PDFs cloned from boscorat/bank-statement-data
- Verifies CI runs with SSH secret integration