### PR TITLE
ci: Add SSH agent setup for private test data repo access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Set up SSH for private repo access
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_TEST_DATA }}
+
       - name: Ruff lint
         run: uv run ruff check .
 


### PR DESCRIPTION
Sets up SSH authentication in the CI workflow to allow cloning test PDFs from the private boscorat/bank-statement-data repository.

This PR contains ONLY the workflow changes. The actual implementation of test PDF cloning will come in subsequent PRs from the `symlink` or `metadata` branches.