### PR TITLE
Improve readability of anonymisation guide and function signatures

### DIFF
--- a/docs/guides/anonymisation.md
+++ b/docs/guides/anonymisation.md
@@ -62,7 +62,13 @@ typically contain real account numbers or names.
 ### `anonymise_pdf()`
 
 ```python
-anonymise_pdf(input_path: str | Path, output_path: str | Path | None = None, always_anonymise_path: str | Path | None = None, never_anonymise_path: str | Path | None = None, debug: bool = False) -> Path
+anonymise_pdf(
+    input_path: str | Path,
+    output_path: str | Path | None = None,
+    always_anonymise_path: str | Path | None = None,
+    never_anonymise_path: str | Path | None = None,
+    debug: bool = False,
+) -> Path
 ```
 
 Anonymise a single bank statement PDF.
@@ -73,20 +79,24 @@ Parameters
 ----------
 input_path:
 Path to the source PDF.
+
 output_path:
 Destination path for the anonymised PDF.  If omitted, the output is
 written to the same directory as the input with the filename prefix
 ``anonymised_`` prepended.  It is strongly recommended to supply an
 explicit output path that does not contain any sensitive information
 (e.g. account numbers or names that may appear in the original filename).
+
 always_anonymise_path:
 Optional path to a user ``always_anonymise.toml`` file.  Entries here
 force specific strings to a known replacement value and take priority
 over the bundled system file.
+
 never_anonymise_path:
 Optional path to a user ``never_anonymise.toml`` file.  Phrases listed
 here are preserved exactly as-is during the scramble pass and are merged
 with the bundled system file.
+
 debug:
 When ``True``, print diagnostic information about config loading,
 fragment classification, and scramble pairs to stdout.

--- a/docs/guides/exports.md
+++ b/docs/guides/exports.md
@@ -42,7 +42,13 @@ bsp process --pdfs ~/statements --no-export
 #### `export_csv()`
 
 ```python
-export_csv(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
+export_csv(
+    folder: Path | None = None,
+    type: Literal['single', 'multi'] = 'single',
+    project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
+) -> None
 ```
 
 Write report data to CSV files in *folder*.
@@ -86,7 +92,13 @@ original names, e.g. ``transactions.csv``.
 #### `export_excel()`
 
 ```python
-export_excel(path: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
+export_excel(
+    path: Path | None = None,
+    type: Literal['single', 'multi'] = 'single',
+    project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
+) -> None
 ```
 
 Write report data to an Excel workbook at *path*.
@@ -127,7 +139,13 @@ Worksheet names are never modified by the timestamp or type logic.
 #### `export_json()`
 
 ```python
-export_json(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
+export_json(
+    folder: Path | None = None,
+    type: Literal['single', 'multi'] = 'single',
+    project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
+) -> None
 ```
 
 Write report data to JSON files in *folder*.

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -285,7 +285,13 @@ Available in `bsp.db`:
 #### `export_csv()`
 
 ```python
-export_csv(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
+export_csv(
+    folder: Path | None = None,
+    type: Literal['single', 'multi'] = 'single',
+    project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
+) -> None
 ```
 
 Write report data to CSV files in *folder*.
@@ -329,7 +335,13 @@ original names, e.g. ``transactions.csv``.
 #### `export_excel()`
 
 ```python
-export_excel(path: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
+export_excel(
+    path: Path | None = None,
+    type: Literal['single', 'multi'] = 'single',
+    project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
+) -> None
 ```
 
 Write report data to an Excel workbook at *path*.
@@ -370,7 +382,13 @@ Worksheet names are never modified by the timestamp or type logic.
 #### `export_json()`
 
 ```python
-export_json(folder: Path | None = None, type: Literal['single', 'multi'] = 'single', project_path: Path | None = None, batch_id: str | None = None, filename_timestamp: bool = False) -> None
+export_json(
+    folder: Path | None = None,
+    type: Literal['single', 'multi'] = 'single',
+    project_path: Path | None = None,
+    batch_id: str | None = None,
+    filename_timestamp: bool = False,
+) -> None
 ```
 
 Write report data to JSON files in *folder*.

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -506,7 +506,7 @@ def _extract_function_docs(source: str, names: list[str]) -> list[FunctionDoc]:
 
 def _build_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
     """Build a human-readable function signature from an AST FunctionDef.
-    
+
     Returns multi-line format (one parameter per line) if the signature
     would exceed 100 characters on a single line.
     """
@@ -535,15 +535,15 @@ def _build_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
 
     # Build single-line version first to check length
     single_line = f"{node.name}({', '.join(parts)}){ret}"
-    
+
     # If it fits on one line (under 100 chars), use that; otherwise format multi-line
     if len(single_line) <= 100:
         return single_line
-    
+
     # Multi-line format: one parameter per line
     if not parts:
         return single_line
-    
+
     lines = [f"{node.name}("]
     for i, part in enumerate(parts):
         if i < len(parts) - 1:

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -505,7 +505,11 @@ def _extract_function_docs(source: str, names: list[str]) -> list[FunctionDoc]:
 
 
 def _build_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
-    """Build a human-readable function signature from an AST FunctionDef."""
+    """Build a human-readable function signature from an AST FunctionDef.
+    
+    Returns multi-line format (one parameter per line) if the signature
+    would exceed 100 characters on a single line.
+    """
     args = node.args
     parts: list[str] = []
 
@@ -529,7 +533,25 @@ def _build_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
     if node.returns:
         ret = f" -> {ast.unparse(node.returns)}"
 
-    return f"{node.name}({', '.join(parts)}){ret}"
+    # Build single-line version first to check length
+    single_line = f"{node.name}({', '.join(parts)}){ret}"
+    
+    # If it fits on one line (under 100 chars), use that; otherwise format multi-line
+    if len(single_line) <= 100:
+        return single_line
+    
+    # Multi-line format: one parameter per line
+    if not parts:
+        return single_line
+    
+    lines = [f"{node.name}("]
+    for i, part in enumerate(parts):
+        if i < len(parts) - 1:
+            lines.append(f"    {part},")
+        else:
+            lines.append(f"    {part},")
+    lines.append(f"){ret}")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bank_statement_parser/modules/anonymise.py
+++ b/src/bank_statement_parser/modules/anonymise.py
@@ -7,8 +7,13 @@ Install the optional dependency to use this module::
 
 Public API
 ----------
-anonymise_pdf(input_path, output_path=None, always_anonymise_path=None,
-              never_anonymise_path=None, debug=False) -> Path
+anonymise_pdf(
+    input_path: str | Path,
+    output_path: str | Path | None = None,
+    always_anonymise_path: str | Path | None = None,
+    never_anonymise_path: str | Path | None = None,
+    debug: bool = False,
+) -> Path
 """
 
 from __future__ import annotations
@@ -39,20 +44,24 @@ def anonymise_pdf(
     ----------
     input_path:
         Path to the source PDF.
+
     output_path:
         Destination path for the anonymised PDF.  If omitted, the output is
         written to the same directory as the input with the filename prefix
         ``anonymised_`` prepended.  It is strongly recommended to supply an
         explicit output path that does not contain any sensitive information
         (e.g. account numbers or names that may appear in the original filename).
+
     always_anonymise_path:
         Optional path to a user ``always_anonymise.toml`` file.  Entries here
         force specific strings to a known replacement value and take priority
         over the bundled system file.
+
     never_anonymise_path:
         Optional path to a user ``never_anonymise.toml`` file.  Phrases listed
         here are preserved exactly as-is during the scramble pass and are merged
         with the bundled system file.
+
     debug:
         When ``True``, print diagnostic information about config loading,
         fragment classification, and scramble pairs to stdout.


### PR DESCRIPTION
## Summary

Resolves readability issues in the anonymisation guide where the `anonymise_pdf()` function signature required horizontal scrolling and parameter descriptions lacked visual separation.

### Changes

**Source docstring improvements** (`src/bank_statement_parser/modules/anonymise.py`):
- Added blank lines between parameter descriptions in the Parameters section
- Updated module-level "Public API" section to show multi-line function signature

**Documentation generation enhancements** (`scripts/generate_docs.py`):
- Enhanced `_build_signature()` to format long function signatures (100+ characters) on multiple lines
- Each parameter now appears on its own line with proper indentation
- Short signatures (≤100 chars) remain single-line for conciseness

**Generated documentation** (`docs/guides/anonymisation.md` + others):
- Regenerated all documentation with improved formatting
- `anonymise_pdf()` signature now displays across 7 lines instead of 1 long line
- Parameters separated by blank lines for better scannability
- No horizontal scrolling required to view all parameters
- Improvement applied across all Python API documentation

### Testing

✅ All 204 tests pass  
✅ No regressions detected  
✅ Documentation renders correctly  

### Before/After

**Before:**
```python
anonymise_pdf(input_path: str | Path, output_path: str | Path | None = None, always_anonymise_path: str | Path | None = None, never_anonymise_path: str | Path | None = None, debug: bool = False) -> Path
```

**After:**
```python
anonymise_pdf(
    input_path: str | Path,
    output_path: str | Path | None = None,
    always_anonymise_path: str | Path | None = None,
    never_anonymise_path: str | Path | None = None,
    debug: bool = False,
) -> Path
```