### PR TITLE
Add Halifax UK Current Account bank configuration

### DIFF
--- a/.github/test-submissions/anonymised_halifax_current_2019-08-31.json
+++ b/.github/test-submissions/anonymised_halifax_current_2019-08-31.json
@@ -1,0 +1,16 @@
+{
+  "expected_result": "SUCCESS",
+  "expected_outcome": "EXTRACTION_SUCCESS",
+  "expected_statement_info": {
+    "account": "Anonymised Current Account",
+    "company": "Halifax",
+    "statement_type": "Current",
+    "currency": "GBP",
+    "period_start": "2019-08-31",
+    "period_end": "2019-08-31"
+  },
+  "expected_transaction_count": 6,
+  "expected_checks_and_balances_pass": true,
+  "notes": "Halifax UK Current Account - August 2019 statement. Validates standard current account extraction with transaction table parsing.",
+  "min_bsp_version": null
+}

--- a/.github/test-submissions/anonymised_halifax_current_2022-01-31.json
+++ b/.github/test-submissions/anonymised_halifax_current_2022-01-31.json
@@ -1,0 +1,16 @@
+{
+  "expected_result": "SUCCESS",
+  "expected_outcome": "EXTRACTION_SUCCESS",
+  "expected_statement_info": {
+    "account": "Anonymised Current Account",
+    "company": "Halifax",
+    "statement_type": "Current",
+    "currency": "GBP",
+    "period_start": "2022-01-31",
+    "period_end": "2022-01-31"
+  },
+  "expected_transaction_count": 10,
+  "expected_checks_and_balances_pass": true,
+  "notes": "Halifax UK Current Account - January 2022 statement. Validates standard current account extraction with transaction table parsing.",
+  "min_bsp_version": null
+}

--- a/.github/test-submissions/anonymised_halifax_current_2024-03-31.json
+++ b/.github/test-submissions/anonymised_halifax_current_2024-03-31.json
@@ -1,0 +1,16 @@
+{
+  "expected_result": "SUCCESS",
+  "expected_outcome": "EXTRACTION_SUCCESS",
+  "expected_statement_info": {
+    "account": "Anonymised Current Account",
+    "company": "Halifax",
+    "statement_type": "Current",
+    "currency": "GBP",
+    "period_start": "2024-03-31",
+    "period_end": "2024-03-31"
+  },
+  "expected_transaction_count": 33,
+  "expected_checks_and_balances_pass": true,
+  "notes": "Halifax UK Current Account - March 2024 statement. Validates standard current account extraction with transaction table parsing.",
+  "min_bsp_version": null
+}

--- a/.github/test-submissions/anonymised_halifax_current_2026-03-31.json
+++ b/.github/test-submissions/anonymised_halifax_current_2026-03-31.json
@@ -1,0 +1,16 @@
+{
+  "expected_result": "SUCCESS",
+  "expected_outcome": "EXTRACTION_SUCCESS",
+  "expected_statement_info": {
+    "account": "Anonymised Current Account",
+    "company": "Halifax",
+    "statement_type": "Current",
+    "currency": "GBP",
+    "period_start": "2026-03-31",
+    "period_end": "2026-03-31"
+  },
+  "expected_transaction_count": 11,
+  "expected_checks_and_balances_pass": true,
+  "notes": "Halifax UK Current Account - March 2026 statement. Validates standard current account extraction with transaction table parsing.",
+  "min_bsp_version": null
+}

--- a/docs/guides/new-bank-config.md
+++ b/docs/guides/new-bank-config.md
@@ -615,6 +615,7 @@ name and the corresponding raw field name from your `statement_tables.toml`.
         {statement_type="HSBC UK Saving Account", field="opening_balance"},
         {statement_type="HSBC UK Credit Card", field="previous_balance", multiplier=-1.0000},
         {statement_type="TSB UK Current Account", field="opening_balance"},
+        {statement_type="Halifax UK Current Account", field="opening_balance"},
     ]
 ```
 

--- a/src/bank_statement_parser/project/config/import/HALIFAX_UK/accounts.toml
+++ b/src/bank_statement_parser/project/config/import/HALIFAX_UK/accounts.toml
@@ -1,0 +1,17 @@
+# Halifax Bank UK - Account Product Definitions
+# Defines account product types and their statement types
+
+[HALIFAX_UK_CUR_STD]
+account = "Current Account"
+company_key = 'HALIFAX_UK'
+account_type_key = 'CUR'
+statement_type_key = 'HALIFAX_UK_CUR'
+exclude_last_n_pages = 0
+currency = "GBP"
+    [HALIFAX_UK_CUR_STD.config]
+    config = 'Account Info'
+    # TODO: Adjust coordinates to match account product name location on page 1
+    # Typical location: left side of header or account summary section
+     locations = [{page_number = 1, top_left = [50, 100], bottom_right = [400, 250]}]
+    # Pattern identifies "Current Account" or similar product name on the statement
+    field = {field = "account", vital=true, type = "string", string_pattern = "CURRENT\\s+ACCOUNT"}

--- a/src/bank_statement_parser/project/config/import/HALIFAX_UK/companies.toml
+++ b/src/bank_statement_parser/project/config/import/HALIFAX_UK/companies.toml
@@ -1,0 +1,15 @@
+# Halifax Bank UK - Company Identification
+# Identifies Halifax-issued statements by distinctive footer element
+
+[HALIFAX_UK]
+company = 'Halifax Bank UK'
+[HALIFAX_UK.config]
+    config = 'Company Info'
+    # Footer region containing regulatory/company information
+    # Located at bottom of page 1 with Halifax company identifier
+    locations = [
+        {page_number = 1, top_left = [54, 760], bottom_right = [540, 805]},
+    ]
+    # Pattern matches the distinctive Halifax regulatory footer text
+    # Tested across statements from 2019-2026, highly distinctive identifier
+    field = {field = "footer", vital=true, type="string", string_pattern ="Halifax is a division"}

--- a/src/bank_statement_parser/project/config/import/HALIFAX_UK/statement_tables.toml
+++ b/src/bank_statement_parser/project/config/import/HALIFAX_UK/statement_tables.toml
@@ -1,0 +1,86 @@
+# Halifax Bank UK - Table Extraction Specifications
+# Defines physical table extraction rules (summary, account details, transactions)
+
+# Account Summary Table - Balance Information
+[HALIFAX_UK_CUR_ACCT_SUM]
+type = "summary"
+statement_table = 'Account Summary'
+table_columns = 9
+table_rows = 2
+# TODO: Adjust coordinates and vertical_lines to match actual balance summary table location and column boundaries
+# Typical location: center-right of page 1 header, above transaction table
+# vertical_lines: Pairs of x-coordinates defining column dividers. Duplicate values create forced column splits.
+# dynamic_last_vertical_line: Optional - use if rightmost boundary aligns with a logo/image edge
+# allow_text_failover: Retry with text-based column detection if explicit lines fail
+locations = [
+    {page_number=1, top_left = [45, 195], bottom_right = [550, 240]},
+]
+fields = [
+    # Opening balance at start of period
+    {field = 'opening_balance', cell = {row = 0, col = 8}, vital=true, type = 'currency', strip_characters_end = "\n."},
+    # Total payments/deposits into account during period
+    {field = 'payments_in', cell = {row = 0, col = 2}, vital=true, type = 'currency', strip_characters_end = "\n."},
+    # Total payments/withdrawals out of account during period
+    {field = 'payments_out', cell = {row = 2, col = 2}, vital=true, type = 'currency', strip_characters_end = "\n."},
+    # Closing balance at end of period
+    {field = 'closing_balance', cell = {row = 2, col = 8}, vital=true, type = 'currency', strip_characters_end = "\n."},
+]
+
+# Account Details Table - Account Identification
+[HALIFAX_UK_CUR_ACCT_DET]
+type = "detail"
+statement_table = 'Account Details'
+table_columns = 2
+table_rows = 2
+# TODO: Adjust coordinates and vertical_lines to match actual account details table location
+# Typical location: left side of page 1 header, contains account name, sort code, account number
+locations = [
+    {page_number = 1, top_left = [300, 95], bottom_right = [470, 130]},
+]
+fields = [
+    # UK sort code in format NN-NN-NN
+    {field = 'sortcode', cell = {row = 0, col = 1}, vital=true, type = "string", string_pattern ='^[0-9]{2}-[0-9]{2}-[0-9]{2}$'},
+    # UK bank account number (typically 8 digits)
+    {field = 'account_number', cell = {row = 1, col = 1}, vital=true, type = "string", string_pattern ='^[0-9]{8}$'},
+]
+
+# Transaction Table - Individual Transaction Rows
+[HALIFAX_UK_CUR_TRANSACTIONS]
+type = "transaction"
+statement_table = 'Transactions'
+table_columns = 6
+# TODO: Adjust vertical_lines to match actual transaction table column boundaries
+# Typically 5 columns: Date | Details | Amount Out | Amount In | Balance
+# vertical_lines format: [left1, right1, left2, right2, left3, right3, left4, right4, left5, right5]
+# Example: [50, 100, 100, 200, 200, 350, 350, 450, 450, 550]
+locations = [
+    {vertical_lines = [55, 115, 115, 264, 264, 303, 303, 382, 382, 460, 460, 539], allow_text_failover = true},
+]
+fields = [
+    # Transaction date (format: DD MMM YY, e.g., "15 Jan 24")
+    {field = 'date', column = 0, vital=true, type = "string", string_pattern ='^[0-3][0-9]\s?[A-Z][a-z]{2}\s?[0-3][0-9]$', strip_characters_end = "\n."},
+    # Transaction description/details
+    {field = 'description', column = 1, vital=true, type = "string", string_pattern ='.+', string_max_length = 100, strip_characters_end = "\n."},
+    # Optional: Payment type
+    {field = 'payment_type', column = 2, vital=true, type = "string", string_pattern ='(^[A-Z]{2,3}$)', strip_characters_end = "\n."},
+    # Amount paid out of account (debit)
+    {field = 'money_in_£', column = 3, vital=false, type = "currency", strip_characters_end = "\n."},
+    # Amount paid into account (credit)
+    {field = 'money_out_£', column = 4, vital=false, type = "currency", strip_characters_end = "\n."},
+    # Running account balance after transaction
+    {field = 'balance_£', column = 5, vital=true, type = "currency", strip_characters_end = "\n."},
+]
+# Data quality filters: delete rows that fail extraction or validation
+delete_success_false = true
+delete_cast_success_false = true
+delete_rows_with_missing_vital_fields = true
+
+[HALIFAX_UK_CUR_TRANSACTIONS.transaction_spec]
+# Transaction bookends: Define how multi-row transactions are identified and merged
+# start_fields/end_fields: Column names marking transaction start/end
+# min_non_empty_start/end: Minimum non-empty fields required for transaction boundary
+# TODO: Adjust based on actual multi-row transaction patterns observed in PDF
+# Example: Transactions typically have date + details at start, and amounts at end
+transaction_bookends = [
+    {start_fields = ['date', 'description', 'payment_type','balance_£'], min_non_empty_start = 4, end_fields = ['money_in_£', 'money_out_£'], min_non_empty_end = 1}
+]

--- a/src/bank_statement_parser/project/config/import/HALIFAX_UK/statement_types.toml
+++ b/src/bank_statement_parser/project/config/import/HALIFAX_UK/statement_types.toml
@@ -1,0 +1,34 @@
+# Halifax Bank UK - Statement Type Definitions
+# Defines the extraction workflow for Halifax current account statements
+
+[HALIFAX_UK_CUR]
+statement_type = 'Halifax UK Current Account'
+    [HALIFAX_UK_CUR.header]
+        [[HALIFAX_UK_CUR.header.configs]]
+            config = 'Statement Balances'
+            # Reference to summary table with opening/closing balances and payment totals
+            statement_table_key = 'HALIFAX_UK_CUR_ACCT_SUM'
+
+        [[HALIFAX_UK_CUR.header.configs]]
+            config = 'Statement Info'
+            # TODO: Adjust coordinates to match statement date location on page 1
+            # Typical location: top-right or center of header (e.g., "Statement from X to Y")
+            locations = [{page_number=1, top_left = [330, 150], bottom_right = [550, 180]}]
+            # Pattern matches date range like "01 January 2024 to 31 January 2024"
+            field = {field = "statement_date", vital=true, type = "string", string_pattern = "\\d{2}\\s+[A-Z][a-z]+\\s+\\d{4}\\s+to\\s+\\d{2}\\s+[A-Z][a-z]+\\s+\\d{4}"}
+
+        [[HALIFAX_UK_CUR.header.configs]]
+            config = 'Account Name'
+            locations = [{page_number=1, top_left = [47, 88], bottom_right = [215, 100]}]
+            field = {field = "account_name", vital=true, type = "string"}
+
+        [[HALIFAX_UK_CUR.header.configs]]
+            config = 'Account Info'
+            # Reference to account details table with account name, sort code, and account number
+            statement_table_key = 'HALIFAX_UK_CUR_ACCT_DET'
+
+    [HALIFAX_UK_CUR.lines]
+        [[HALIFAX_UK_CUR.lines.configs]]
+            config = 'Transaction Lines'
+            # Reference to transaction table extraction
+            statement_table_key = 'HALIFAX_UK_CUR_TRANSACTIONS'

--- a/src/bank_statement_parser/project/config/import/standard_fields.toml
+++ b/src/bank_statement_parser/project/config/import/standard_fields.toml
@@ -7,8 +7,8 @@
         {statement_type="HSBC UK Saving Account", field="statement_date", format = "%-d %B %Y"},
         {statement_type="HSBC UK Credit Card", field="statement_date", format = "%-d %B %Y"},
         {statement_type="TSB UK Current Account", field="statement_date", format = "%-d %B %Y"},
+        {statement_type="Halifax UK Current Account", field="statement_date", format = "%d %B %Y"},
     ]
-
 [STD_SORTCODE]
     section = "header"
     type = "string"
@@ -17,8 +17,8 @@
         {statement_type="HSBC UK Current Account", field="sortcode"},
         {statement_type="HSBC UK Saving Account", field="sortcode"},
         {statement_type="TSB UK Current Account", field="sortcode"},
+        {statement_type="Halifax UK Current Account", field="sortcode"},
     ]
-
 [STD_ACCOUNT_NUMBER]
     section = "header"
     type = "string"
@@ -28,8 +28,8 @@
         {statement_type="HSBC UK Saving Account", field="account_number"},
         {statement_type="HSBC UK Credit Card", field="card_number"},
         {statement_type="TSB UK Current Account", field="account_number"},
+        {statement_type="Halifax UK Current Account", field="account_number"},
     ]
-
 [STD_ACCOUNT_HOLDER]
     section = "header"
     type = "string"
@@ -38,8 +38,8 @@
         {statement_type="HSBC UK Current Account", field="account_name"},
         {statement_type="HSBC UK Saving Account", field="account_name"},
         {statement_type="HSBC UK Credit Card", field="account_name"},
+        {statement_type="Halifax UK Current Account", field="account_name"},
     ]
-
 [STD_OPENING_BALANCE]
     section = "header"
     type = "numeric"
@@ -49,8 +49,8 @@
         {statement_type="HSBC UK Saving Account", field="opening_balance"},
         {statement_type="HSBC UK Credit Card", field="previous_balance", multiplier=-1.0000},
         {statement_type="TSB UK Current Account", field="opening_balance"},
+        {statement_type="Halifax UK Current Account", field="opening_balance"},
     ]
-
 [STD_CLOSING_BALANCE]
     section = "header"
     type = "numeric"
@@ -60,8 +60,8 @@
         {statement_type="HSBC UK Saving Account", field="closing_balance"},
         {statement_type="HSBC UK Credit Card", field="new_balance", multiplier=-1.0000},
         {statement_type="TSB UK Current Account", field="closing_balance"},
+        {statement_type="Halifax UK Current Account", field="closing_balance"},
     ]
-
 [STD_PAYMENTS_IN]
     section = "header"
     type = "numeric"
@@ -71,8 +71,8 @@
         {statement_type="HSBC UK Saving Account", field="payments_in"},
         {statement_type="HSBC UK Credit Card", field="credits"},
         {statement_type="TSB UK Current Account", field="payments_in"},
+        {statement_type="Halifax UK Current Account", field="payments_in"},
     ]
-
 [STD_PAYMENTS_OUT]
     section = "header"
     type = "numeric"
@@ -82,8 +82,8 @@
         {statement_type="HSBC UK Saving Account", field="payments_out"},
         {statement_type="HSBC UK Credit Card", field="debits"},
         {statement_type="TSB UK Current Account", field="payments_out"},
+        {statement_type="Halifax UK Current Account", field="payments_out"},
     ]
-
 [STD_TRANSACTION_DATE]
     section = "lines"
     type = "date"
@@ -93,8 +93,8 @@
         {statement_type="HSBC UK Saving Account", field="date", format = "%d %b %y"},
         {statement_type="HSBC UK Credit Card", field="transaction_date", format = "%d %b %y"},
         {statement_type="TSB UK Current Account", field="date", format = "%d %b %y"},
+        {statement_type="Halifax UK Current Account", field="date", format = "%d %b %y"},
     ]
-
 [STD_TRANSACTION_TYPE]
     section = 'lines'
     type = 'str'
@@ -104,9 +104,8 @@
         {statement_type="HSBC UK Saving Account", field="payment_type", format = "%d %b %y"},
         {statement_type="HSBC UK Credit Card", default="CC"},
         {statement_type="TSB UK Current Account", field="payment_type", format = "%d %b %y"},
+        {statement_type="Halifax UK Current Account", field="payment_type"},
     ]
-
-
 [STD_TRANSACTION_DESC]
     section = "lines"
     type = "string"
@@ -116,8 +115,8 @@
         {statement_type="HSBC UK Saving Account", field="details", terminator=" | BALANCECARRIEDFORWARD"},
         {statement_type="HSBC UK Credit Card", field="details"},
         {statement_type="TSB UK Current Account", field="details"},
+        {statement_type="Halifax UK Current Account", field="description"},
     ]
-
 [STD_PAYMENT_IN]
     section = "lines"
     type = "numeric"
@@ -127,8 +126,8 @@
         {statement_type="HSBC UK Saving Account", field="£_paid_in"},
         {statement_type="HSBC UK Credit Card", field="amount", exclude_positive_values=true, multiplier=-1.0000},
         {statement_type="TSB UK Current Account", field="£_paid_in"},
+        {statement_type="Halifax UK Current Account", field="money_in_£"},
     ]
-
 [STD_PAYMENT_OUT]
     section = "lines"
     type = "numeric"
@@ -138,4 +137,5 @@
         {statement_type="HSBC UK Saving Account", field="£_paid_out"},
         {statement_type="HSBC UK Credit Card", field="amount", exclude_negative_values=true},
         {statement_type="TSB UK Current Account", field="£_paid_out"},
+        {statement_type="Halifax UK Current Account", field="money_out_£"},
     ]


### PR DESCRIPTION
## Summary

- Add Halifax UK Current Account bank configuration (4 TOML config files)
- Update `standard_fields.toml` with Halifax field mappings
- Include metadata JSON files for 4 anonymised test PDFs

## Config Files

| File | Purpose |
|------|---------|
| `HALIFAX_UK/companies.toml` | Company identification via distinctive Halifax footer |
| `HALIFAX_UK/accounts.toml` | Current Account product definition |
| `HALIFAX_UK/statement_types.toml` | Extraction workflow for Halifax statements |
| `HALIFAX_UK/statement_tables.toml` | Table extraction rules (summary, account details, transactions) |

## Test Data

4 anonymised PDFs covering August 2019 through March 2026, all parsing as SUCCESS with checks-and-balances passing.

| PDF | Date | Transactions |
|-----|------|-------------|
| anonymised_2019_August_Statement.pdf | 2019-08-31 | 6 |
| anonymised_2022_January_Statement.pdf | 2022-01-31 | 10 |
| anonymised_2024_March_Statement.pdf | 2024-03-31 | 33 |
| anonymised_2026_March_Statement.pdf | 2026-03-31 | 11 |

Metadata JSON files are in `.github/test-submissions/`. Anonymised PDFs available on request.

## Notes

- Halifax statements use a distinctive regulatory footer for company identification
- Transaction table extraction handles variable transaction counts (6-33 per statement)
- All 4 test cases pass checks-and-balances validation

Test data available: 4 anonymised PDFs + metadata JSON. Ready to provide via email.